### PR TITLE
ci: Properly set concurrency group for chore workflow

### DIFF
--- a/.github/workflows/chore.yml
+++ b/.github/workflows/chore.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, edited, synchronize]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Motivation

The current setup cancels concurrent runs as `ref` is `main`.
