### PR TITLE
fix: Synthesize SnapshotInfo for expired inline data

### DIFF
--- a/crates/ducklake/src/caches/snapshot.rs
+++ b/crates/ducklake/src/caches/snapshot.rs
@@ -9,7 +9,7 @@ use crate::caches::TableStats;
 use crate::catalog::Catalog;
 use crate::primitives::AsyncLazy;
 use crate::spec::*;
-use crate::{DucklakeResult, db};
+use crate::{DucklakeError, DucklakeResult, db};
 
 #[derive(Clone)]
 pub struct SnapshotCache {
@@ -67,11 +67,26 @@ impl SnapshotCache {
             return Ok(snapshot.clone());
         }
 
-        // If not, we need to fetch it
-        let snapshot_info =
-            SnapshotInfo::load_for_schema_version(&self.pool, schema_version).await?;
-        let snapshot = self.insert_snapshot(snapshot_info);
-        Ok(snapshot)
+        // Try to find a live snapshot at this schema_version.
+        if let Some(info) =
+            SnapshotInfo::try_load_for_schema_version(&self.pool, schema_version).await?
+        {
+            return Ok(self.insert_snapshot(info));
+        }
+
+        // Fall back to ducklake_schema_versions. ducklake_expire_snapshots prunes
+        // ducklake_snapshot but retains ducklake_schema_versions so older data files (and
+        // ducklake_inlined_data_tables) can still be projected through their historical
+        // schema. The synthesized SnapshotInfo is intentionally not cached: its sentinel
+        // `next_catalog_id` / `next_file_id` / `snapshot_time` are correct for the read path
+        // that lands here, but would be wrong for any cache hit that later reaches the
+        // table_stats accessor.
+        let info = SnapshotInfo::synthesize_for_schema_version(&self.pool, schema_version).await?;
+        Ok(Arc::new(Snapshot::new(
+            info,
+            self.catalog_cache.clone(),
+            self.table_stats_cache.clone(),
+        )))
     }
 
     /* ----------------------------------------- MODIFY ---------------------------------------- */
@@ -201,11 +216,11 @@ impl SnapshotInfo {
         Ok(snapshot.into())
     }
 
-    async fn load_for_schema_version(
+    async fn try_load_for_schema_version(
         pool: &db::Pool,
         schema_version: i64,
-    ) -> DucklakeResult<Self> {
-        // Read the latest snapshot for the given schema version
+    ) -> DucklakeResult<Option<Self>> {
+        // Read the latest live snapshot for the given schema version.
         let query = Query::select()
             .column(Asterisk)
             .from(ducklake_snapshot::Table)
@@ -220,10 +235,48 @@ impl SnapshotInfo {
             )
             .limit(1)
             .to_owned();
-        let snapshot: DucklakeSnapshot = pool.fetch_one(&query).await?;
+        let snapshot: Option<DucklakeSnapshot> = pool.fetch_optional(&query).await?;
+        Ok(snapshot.map(Into::into))
+    }
 
-        // Translate into snapshot struct
-        Ok(snapshot.into())
+    async fn synthesize_for_schema_version(
+        pool: &db::Pool,
+        schema_version: i64,
+    ) -> DucklakeResult<Self> {
+        // Used when ducklake_expire_snapshots has pruned every snapshot at this
+        // schema_version but ducklake_schema_versions still references it. The catalog can be
+        // reconstructed from any snapshot id that falls inside the schema_version's validity
+        // range; we use the earliest begin_snapshot recorded for it.
+        let query = Query::select()
+            .column(ducklake_schema_versions::Column::BeginSnapshot)
+            .from(ducklake_schema_versions::Table)
+            .and_where(
+                ducklake_schema_versions::Column::SchemaVersion
+                    .col()
+                    .eq(schema_version),
+            )
+            .order_by(
+                ducklake_schema_versions::Column::BeginSnapshot,
+                sea_query::Order::Asc,
+            )
+            .limit(1)
+            .to_owned();
+        let row: Option<(i64,)> = pool.fetch_optional(&query).await?;
+        let begin_snapshot = row
+            .ok_or_else(|| DucklakeError::NotFound {
+                entity: "schema_version",
+                name: schema_version.to_string(),
+            })?
+            .0;
+
+        Ok(Self {
+            id: begin_snapshot,
+            schema_version,
+            next_catalog_id: 0,
+            next_file_id: 0,
+            snapshot_time: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0)
+                .expect("unix epoch is a valid timestamp"),
+        })
     }
 }
 

--- a/crates/ducklake/src/caches/snapshot.rs
+++ b/crates/ducklake/src/caches/snapshot.rs
@@ -266,7 +266,7 @@ impl SnapshotInfo {
         // Negative next_catalog_id and next_file_id to be abundantly clear these are fake
         Ok(Self {
             id: begin_snapshot,
-            schema_version: schema_version,
+            schema_version,
             next_catalog_id: -1,
             next_file_id: -1,
             snapshot_time: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),

--- a/crates/ducklake/src/caches/snapshot.rs
+++ b/crates/ducklake/src/caches/snapshot.rs
@@ -9,7 +9,7 @@ use crate::caches::TableStats;
 use crate::catalog::Catalog;
 use crate::primitives::AsyncLazy;
 use crate::spec::*;
-use crate::{DucklakeError, DucklakeResult, db};
+use crate::{DucklakeResult, db};
 
 #[derive(Clone)]
 pub struct SnapshotCache {
@@ -69,7 +69,7 @@ impl SnapshotCache {
 
         // Try to find a live snapshot at this schema_version.
         if let Some(info) =
-            SnapshotInfo::try_load_for_schema_version(&self.pool, schema_version).await?
+            SnapshotInfo::load_for_schema_version(&self.pool, schema_version).await?
         {
             return Ok(self.insert_snapshot(info));
         }
@@ -216,7 +216,7 @@ impl SnapshotInfo {
         Ok(snapshot.into())
     }
 
-    async fn try_load_for_schema_version(
+    async fn load_for_schema_version(
         pool: &db::Pool,
         schema_version: i64,
     ) -> DucklakeResult<Option<Self>> {
@@ -261,21 +261,15 @@ impl SnapshotInfo {
             )
             .limit(1)
             .to_owned();
-        let row: Option<(i64,)> = pool.fetch_optional(&query).await?;
-        let begin_snapshot = row
-            .ok_or_else(|| DucklakeError::NotFound {
-                entity: "schema_version",
-                name: schema_version.to_string(),
-            })?
-            .0;
+        let (begin_snapshot,): (i64,) = pool.fetch_one(&query).await?;
 
+        // Negative next_catalog_id and next_file_id to be abundantly clear these are fake
         Ok(Self {
             id: begin_snapshot,
-            schema_version,
-            next_catalog_id: 0,
-            next_file_id: 0,
-            snapshot_time: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0)
-                .expect("unix epoch is a valid timestamp"),
+            schema_version: schema_version,
+            next_catalog_id: -1,
+            next_file_id: -1,
+            snapshot_time: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
         })
     }
 }

--- a/crates/ducklake/src/db/AGENTS.md
+++ b/crates/ducklake/src/db/AGENTS.md
@@ -19,8 +19,9 @@ This design allows the same code to work with any supported database without run
 
 The module exposes two primary types:
 
-- `Pool`: A single-connection pool to the metadata database. Provides methods for querying (`fetch_one`, `fetch_all`),
-  executing statements (`execute`), checking table existence (`table_exists`), and beginning transactions (`begin`).
+- `Pool`: A single-connection pool to the metadata database. Provides methods for querying (`fetch_one`,
+  `fetch_optional`, `fetch_all`), executing statements (`execute`), checking table existence (`table_exists`), and
+  beginning transactions (`begin`).
 - `Transaction`: A database transaction with `REPEATABLE READ` isolation level. Provides methods for executing
   statements and fetching results within the transaction context.
 

--- a/crates/ducklake/src/db/mod.rs
+++ b/crates/ducklake/src/db/mod.rs
@@ -166,6 +166,36 @@ impl Pool {
         Ok(result)
     }
 
+    pub async fn fetch_optional<O, Q>(&self, query: &Q) -> DucklakeResult<Option<O>>
+    where
+        O: RowType,
+        Q: SqlConvertible,
+    {
+        let (sql, values) = query.to_sql(self.dialect());
+        log_sql(&sql, Some(&values));
+        let result = match &self.0 {
+            #[cfg(feature = "postgres")]
+            AnyPool::Postgres(pool) => {
+                sqlx::query_as_with(&sql, values)
+                    .fetch_optional(pool)
+                    .await?
+            }
+            #[cfg(feature = "mysql")]
+            AnyPool::MySql(pool) => {
+                sqlx::query_as_with(&sql, values)
+                    .fetch_optional(pool)
+                    .await?
+            }
+            #[cfg(feature = "sqlite")]
+            AnyPool::Sqlite(pool) => {
+                sqlx::query_as_with(&sql, values)
+                    .fetch_optional(pool)
+                    .await?
+            }
+        };
+        Ok(result)
+    }
+
     pub async fn fetch_all_arrow<Q>(
         &self,
         query: &Q,

--- a/tests/unit/ducklake/test_maintenance.py
+++ b/tests/unit/ducklake/test_maintenance.py
@@ -182,20 +182,21 @@ def test_checkpoint(ducklake: dl.Ducklake, random_table_name: str) -> None:
 
 def test_scan_after_expire_with_orphan_schema_versions(
     ducklake: dl.Ducklake,
+    catalog_url: str,
     random_table_name: str,
 ) -> None:
-    # Arrange: write at two distinct schema_versions and expire, leaving the older one
-    # referenced only by ducklake_schema_versions / ducklake_inlined_data_tables.
-
+    # Arrange
     table = ducklake.create_table(random_table_name, {"a": dl.Int64()})
     table.write_polars(pl.DataFrame({"a": [1]}))
     table.add_column(dl.Column("b", dl.Varchar()))
     table.write_polars(pl.DataFrame({"a": [2], "b": "two"}))
     ducklake.expire_snapshots(older_than=dt.datetime.now(dt.timezone.utc))
 
-    result = ducklake.get_table(f"{random_table_name}").scan()
-    # We expect one inlined array for each insert
-    assert len(result.inline_data) == 2
+    # Act: re-connect on same catalog to go around the cache
+    with dl.connect(catalog_url) as reader:
+        result = reader.get_table(random_table_name).scan()
 
-    row_counts = [pl.DataFrame(arr).height for arr in result.inline_data]
+    # Assert
+    assert len(result.inline_data) == 2
+    row_counts = sorted(pl.DataFrame(arr).height for arr in result.inline_data)
     assert row_counts == [1, 1]

--- a/tests/unit/ducklake/test_maintenance.py
+++ b/tests/unit/ducklake/test_maintenance.py
@@ -6,6 +6,7 @@ import pytest
 
 import ducklake as dl
 
+
 pytestmark = pytest.mark.skip_config(
     catalog="mysql", reason="The DuckDB MySQL connector is unreliable."
 )
@@ -180,22 +181,21 @@ def test_checkpoint(ducklake: dl.Ducklake, random_table_name: str) -> None:
 
 
 def test_scan_after_expire_with_orphan_schema_versions(
-    catalog_url: str, storage_path: str, random_table_name: str
+    ducklake: dl.Ducklake,
+    random_table_name: str,
 ) -> None:
     # Arrange: write at two distinct schema_versions and expire, leaving the older one
     # referenced only by ducklake_schema_versions / ducklake_inlined_data_tables.
-    with dl.create(catalog_url, data_path=storage_path) as setup:
-        con = setup._duckdb_connection
-        con.execute("CALL ducklake_set_option('my_ducklake', 'data_inlining_row_limit', '100')")
-        con.execute(f'CREATE TABLE main."{random_table_name}" (a INTEGER)')
-        con.execute(f'INSERT INTO main."{random_table_name}" VALUES (1)')
-        con.execute(f'ALTER TABLE main."{random_table_name}" ADD COLUMN b VARCHAR')
-        con.execute(f"INSERT INTO main.\"{random_table_name}\" VALUES (2, 'two')")
-        setup.expire_snapshots(older_than=dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=1))
 
-    # Act
-    with dl.connect(catalog_url) as fresh:
-        result = fresh.get_table(f"main.{random_table_name}").scan()
+    table = ducklake.create_table(random_table_name, {"a": dl.Int64()})
+    table.write_polars(pl.DataFrame({"a": [1]}))
+    table.add_column(dl.Column("b", dl.Varchar()))
+    table.write_polars(pl.DataFrame({"a": [2], "b" : "two"}))
+    ducklake.expire_snapshots(older_than=dt.datetime.now(dt.timezone.utc))
 
-    # Assert
-    assert isinstance(result, dl.ScanResult)
+    result = ducklake.get_table(f"{random_table_name}").scan()
+    # We expect one inlined array for each insert
+    assert len(result.inline_data) == 2
+
+    row_counts = [pl.DataFrame(arr).height for arr in result.inline_data]
+    assert row_counts == [1,1]

--- a/tests/unit/ducklake/test_maintenance.py
+++ b/tests/unit/ducklake/test_maintenance.py
@@ -177,3 +177,25 @@ def test_checkpoint(ducklake: dl.Ducklake, random_table_name: str) -> None:
     # Assert: files were merged and data is intact
     assert len(table.scan().data_files) == 1
     assert table.read_arrow().num_rows == 3
+
+
+def test_scan_after_expire_with_orphan_schema_versions(
+    catalog_url: str, storage_path: str, random_table_name: str
+) -> None:
+    # Arrange: write at two distinct schema_versions and expire, leaving the older one
+    # referenced only by ducklake_schema_versions / ducklake_inlined_data_tables.
+    with dl.create(catalog_url, data_path=storage_path) as setup:
+        con = setup._duckdb_connection
+        con.execute("CALL ducklake_set_option('my_ducklake', 'data_inlining_row_limit', '100')")
+        con.execute(f'CREATE TABLE main."{random_table_name}" (a INTEGER)')
+        con.execute(f'INSERT INTO main."{random_table_name}" VALUES (1)')
+        con.execute(f'ALTER TABLE main."{random_table_name}" ADD COLUMN b VARCHAR')
+        con.execute(f"INSERT INTO main.\"{random_table_name}\" VALUES (2, 'two')")
+        setup.expire_snapshots(older_than=dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=1))
+
+    # Act
+    with dl.connect(catalog_url) as fresh:
+        result = fresh.get_table(f"main.{random_table_name}").scan()
+
+    # Assert
+    assert isinstance(result, dl.ScanResult)

--- a/tests/unit/ducklake/test_maintenance.py
+++ b/tests/unit/ducklake/test_maintenance.py
@@ -6,7 +6,6 @@ import pytest
 
 import ducklake as dl
 
-
 pytestmark = pytest.mark.skip_config(
     catalog="mysql", reason="The DuckDB MySQL connector is unreliable."
 )

--- a/tests/unit/ducklake/test_maintenance.py
+++ b/tests/unit/ducklake/test_maintenance.py
@@ -190,7 +190,7 @@ def test_scan_after_expire_with_orphan_schema_versions(
     table = ducklake.create_table(random_table_name, {"a": dl.Int64()})
     table.write_polars(pl.DataFrame({"a": [1]}))
     table.add_column(dl.Column("b", dl.Varchar()))
-    table.write_polars(pl.DataFrame({"a": [2], "b" : "two"}))
+    table.write_polars(pl.DataFrame({"a": [2], "b": "two"}))
     ducklake.expire_snapshots(older_than=dt.datetime.now(dt.timezone.utc))
 
     result = ducklake.get_table(f"{random_table_name}").scan()
@@ -198,4 +198,4 @@ def test_scan_after_expire_with_orphan_schema_versions(
     assert len(result.inline_data) == 2
 
     row_counts = [pl.DataFrame(arr).height for arr in result.inline_data]
-    assert row_counts == [1,1]
+    assert row_counts == [1, 1]


### PR DESCRIPTION
# Motivation
Fixes #19 

Schema evolution fails for inlined data because the `ducklake_expire_snapshots`  stored function prunes rows from the `ducklake_snapshot` table.

# Changes
1. Added `db::Pool::fetch_optional` which returns returns `DucklakeResult<Option<O>>`
2. Split `SnapshotInfo::load_for_schema_version` to `SnapshotInfo::try_load_for_schema_version` and utilized the new `db::Pool::fetch_optional` method.
3. Added `SnapshotInfo::synthesize_for_schema_version` method which will create a synthetic snapshot from the `ducklake_schema_versions` table.
4. Updated the `SnapshotCache::get_for_schema_version`. If we find the snapshot info for the schema version, continue down the original path. If there is no valid snapshot, create a synthetic one and return that.

# Tests

Added `tests/unit/ducklake/test_maintenance.py::test_scan_after_expire_with_orphan_schema_versions`.

Ran `pixi run test-py`

# Lint

Ran `pixi run lint`

