### PR TITLE
fix: Format boolean as '0' or '1' as string

### DIFF
--- a/crates/ducklake/src/spec/literals/primitive.rs
+++ b/crates/ducklake/src/spec/literals/primitive.rs
@@ -1,3 +1,5 @@
+// Literal encoding/decoding follows the ducklake specs statistics encoding
+// https://ducklake.select/docs/stable/specification/data_types#type-encoding-for-statistics
 use chrono::{NaiveDate, NaiveTime};
 use rust_decimal::Decimal;
 use uuid::Uuid;
@@ -19,25 +21,6 @@ macro_rules! str_literal {
     };
 }
 
-// Custom logic for bool to match Ducklake spec: https://ducklake.select/docs/stable/specification/data_types#type-encoding-for-statistics
-impl Literal for bool {
-    fn parse(s: &str) -> DucklakeResult<Self> {
-        match s.to_ascii_lowercase().as_str() {
-            "true" | "1" => Ok(true),
-            "false" | "0" => Ok(false),
-            _ => Err(DucklakeError::Parsing(s.to_string())),
-        }
-    }
-
-    fn format(&self) -> String {
-        if *self {
-            "1".to_string()
-        } else {
-            "0".to_string()
-        }
-    }
-}
-
 str_literal!(i8);
 str_literal!(i16);
 str_literal!(i32);
@@ -55,6 +38,24 @@ str_literal!(NaiveTime);
 str_literal!(NaiveDate);
 str_literal!(String);
 str_literal!(Uuid);
+
+impl Literal for bool {
+    fn parse(s: &str) -> DucklakeResult<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "1" => Ok(true),
+            "0" => Ok(false),
+            _ => Err(DucklakeError::Parsing(s.to_string())),
+        }
+    }
+
+    fn format(&self) -> String {
+        if *self {
+            "1".to_string()
+        } else {
+            "0".to_string()
+        }
+    }
+}
 
 /* -------------------------------------------- BLOB ------------------------------------------- */
 

--- a/crates/ducklake/src/spec/literals/primitive.rs
+++ b/crates/ducklake/src/spec/literals/primitive.rs
@@ -3,7 +3,7 @@ use rust_decimal::Decimal;
 use uuid::Uuid;
 
 use super::Literal;
-use crate::DucklakeResult;
+use crate::{DucklakeError, DucklakeResult};
 
 macro_rules! str_literal {
     ($name:ident) => {
@@ -19,7 +19,25 @@ macro_rules! str_literal {
     };
 }
 
-str_literal!(bool);
+// Custom logic for bool to match Ducklake spec: https://ducklake.select/docs/stable/specification/data_types#type-encoding-for-statistics
+impl Literal for bool {
+    fn parse(s: &str) -> DucklakeResult<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "true" | "1" => Ok(true),
+            "false" | "0" => Ok(false),
+            _ => Err(DucklakeError::Parsing(s.to_string())),
+        }
+    }
+
+    fn format(&self) -> String {
+        if *self {
+            "1".to_string()
+        } else {
+            "0".to_string()
+        }
+    }
+}
+
 str_literal!(i8);
 str_literal!(i16);
 str_literal!(i32);
@@ -64,8 +82,8 @@ mod tests {
     use super::*;
 
     #[rstest]
-    #[case("true", true)]
-    #[case("false", false)]
+    #[case("1", true)]
+    #[case("0", false)]
     fn test_bool_roundtrip(#[case] input: &str, #[case] expected: bool) {
         let parsed = <bool as Literal>::parse(input).unwrap();
         assert_eq!(parsed, expected);

--- a/crates/ducklake/src/typedefs/value/mod.rs
+++ b/crates/ducklake/src/typedefs/value/mod.rs
@@ -120,8 +120,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case(DataType::Boolean, "true", Value::Boolean(true))]
-    #[case(DataType::Boolean, "false", Value::Boolean(false))]
+    #[case(DataType::Boolean, "1", Value::Boolean(true))]
+    #[case(DataType::Boolean, "0", Value::Boolean(false))]
     #[case(DataType::Int8, "-8", Value::Int8(-8))]
     #[case(DataType::Int16, "1234", Value::Int16(1234))]
     #[case(DataType::Int32, "-2147483648", Value::Int32(i32::MIN))]
@@ -301,7 +301,7 @@ mod tests {
     /* -------------------------------------- FORMAT / DISPLAY ------------------------------------- */
 
     #[rstest]
-    #[case(Value::Boolean(true), "true")]
+    #[case(Value::Boolean(true), "1")]
     #[case(Value::Int32(-42), "-42")]
     #[case(Value::Int64(100), "100")]
     #[case(Value::UInt32(u32::MAX), "4294967295")]


### PR DESCRIPTION
# Motivation

Issue: #21 

SDK encodes bool as "true" or "false" rather than "1" or "0" for statistics, which conflicts with the spec.

# Changes
Added custom `parse` and `format` methods for the `Literal` trait for `bool`. The change is backwards compatible with previously written rows in `ducklake_file_column_stats` or `ducklake_table_column_stats`.