### PR TITLE
feat: Allow re-creating a table within a single transaction

### DIFF
--- a/crates/ducklake/src/catalog/mod.rs
+++ b/crates/ducklake/src/catalog/mod.rs
@@ -155,7 +155,7 @@ impl Catalog {
                 .map(|col| (table_idx, col.column).into())
                 .collect()
         });
-        Ok((schema.into(), table_idx.into(), column_refs, partition_refs))
+        Ok((schema.ref_(), table_idx.into(), column_refs, partition_refs))
     }
 
     /// Get the IDs of all tables and their schemas, optionally filtered by schema name.

--- a/crates/ducklake/src/catalog/typedefs/state.rs
+++ b/crates/ducklake/src/catalog/typedefs/state.rs
@@ -5,7 +5,7 @@
 /// that they exist locally without an entity ID assigned yet. Entities that are deleted within the
 /// transaction are marked as `Deleted` to keep the information around until committing the
 /// changes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub(in crate::catalog) enum CatalogState {
     Pending,
     Existing { id: i64 },

--- a/crates/ducklake/src/catalog/views/schema.rs
+++ b/crates/ducklake/src/catalog/views/schema.rs
@@ -74,12 +74,6 @@ impl TryIntoRef<SchemaRef> for i64 {
 /*                                          READ & WRITE                                         */
 /* --------------------------------------------------------------------------------------------- */
 
-impl<'a, C> From<SchemaView<'a, C>> for SchemaRef {
-    fn from(value: SchemaView<'a, C>) -> Self {
-        SchemaRef(value.arena_idx)
-    }
-}
-
 impl<'a, C: Deref<Target = Catalog>> SchemaView<'a, C> {
     pub(in crate::catalog) fn inner(&self) -> &CatalogSchema {
         match &self.catalog.arena[self.arena_idx.0] {
@@ -101,6 +95,10 @@ impl<'a> SchemaViewMut<'a> {
 /* ----------------------------------------- ACCESSORS ----------------------------------------- */
 
 impl<'a, C: Deref<Target = Catalog>> SchemaView<'a, C> {
+    pub fn ref_(&self) -> SchemaRef {
+        SchemaRef(self.arena_idx)
+    }
+
     pub fn id(&self) -> Option<i64> {
         self.inner().state.id()
     }

--- a/crates/ducklake/src/catalog/views/table.rs
+++ b/crates/ducklake/src/catalog/views/table.rs
@@ -296,7 +296,7 @@ impl<'a> TableViewMut<'a> {
         let table = self.inner_mut();
         match table.state {
             CatalogState::Existing { id } => {
-                table.state = CatalogState::Deleted { id: id };
+                table.state = CatalogState::Deleted { id };
                 let name = table.name.name.clone();
                 self.catalog.by_id.remove(&id);
                 self.parent_schema_mut().inner_mut().tables.remove(&name);

--- a/crates/ducklake/src/catalog/views/table.rs
+++ b/crates/ducklake/src/catalog/views/table.rs
@@ -87,11 +87,20 @@ impl<'a, C: Deref<Target = Catalog>> TableView<'a, C> {
     pub(in crate::catalog) fn inner(&self) -> &CatalogTable {
         self.catalog.table_by_idx(self.arena_idx)
     }
+
+    pub fn parent_schema(&self) -> super::schema::SchemaView<'_> {
+        self.catalog.schema(&self.name().schema).unwrap()
+    }
 }
 
 impl<'a> TableViewMut<'a> {
     pub(in crate::catalog) fn inner_mut(&mut self) -> &mut CatalogTable {
         self.catalog.table_by_idx_mut(self.arena_idx)
+    }
+
+    pub fn parent_schema_mut(&mut self) -> super::schema::SchemaViewMut<'_> {
+        let schema_view = self.catalog.schema(&self.name().schema).unwrap();
+        self.catalog.schema_mut(schema_view.ref_()).unwrap()
     }
 }
 
@@ -114,10 +123,6 @@ impl Catalog {
 /* ----------------------------------------- ACCESSORS ----------------------------------------- */
 
 impl<'a, C: Deref<Target = Catalog>> TableView<'a, C> {
-    pub fn parent_schema(&self) -> super::schema::SchemaView<'_> {
-        self.catalog.schema(&self.name().schema).unwrap()
-    }
-
     pub fn ref_(&self) -> TableRef {
         self.arena_idx.into()
     }
@@ -289,15 +294,21 @@ impl<'a> TableViewMut<'a> {
     /// Delete the table with the given identifier by marking it as deleted.
     pub fn delete(&mut self) -> DucklakeResult<()> {
         let table = self.inner_mut();
-        match &table.state {
+        match table.state {
             CatalogState::Existing { id } => {
-                table.state = CatalogState::Deleted { id: *id };
+                table.state = CatalogState::Deleted { id: id };
+                let name = table.name.name.clone();
+                self.catalog.by_id.remove(&id);
+                self.parent_schema_mut().inner_mut().tables.remove(&name);
                 Ok(())
             }
-            CatalogState::Pending => Err(DucklakeError::InvalidChanges(format!(
-                "cannot delete table {} which was created in the same transaction",
-                table.name
-            ))),
+            CatalogState::Pending => {
+                // NOTE: We simply keep the table around as 'pending'. There's no harm in having
+                //  this "orphan" table in the arena
+                let name = table.name.name.clone();
+                self.parent_schema_mut().inner_mut().tables.remove(&name);
+                Ok(())
+            }
             CatalogState::Deleted { .. } => Err(DucklakeError::table_not_found(&table.name)),
         }
     }

--- a/crates/ducklake/src/transaction/changes/change.rs
+++ b/crates/ducklake/src/transaction/changes/change.rs
@@ -55,7 +55,7 @@ impl ChangeSet {
             })
             .collect();
         changes.retain(|c| match c {
-            Change::DeleteTable { table_ref } => !created_tables.contains(&table_ref),
+            Change::DeleteTable { table_ref } => !created_tables.contains(table_ref),
             c => c
                 .affected_table_ref()
                 .map(|r| !deleted_tables.contains(&r))

--- a/crates/ducklake/src/transaction/changes/change.rs
+++ b/crates/ducklake/src/transaction/changes/change.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use itertools::Itertools;
 
 use super::{AppliedChange, AppliedChangeSet};
@@ -28,7 +30,44 @@ impl ChangeSet {
             .unique_by(|c| HashableChange::from(c))
             .collect_vec();
         changes.reverse();
+
+        // We also have to handle some special cases: if a table is deleted, all previous changes
+        // to this table become irrelevant and should be removed. If a table is created in the
+        // same transaction, the drop itself should also be removed.
+        let created_tables: HashSet<_> = changes
+            .iter()
+            .filter_map(|c| {
+                if let Change::CreateTable { table_ref, .. } = c {
+                    Some(*table_ref)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let deleted_tables: HashSet<_> = changes
+            .iter()
+            .filter_map(|c| {
+                if let Change::DeleteTable { table_ref } = c {
+                    Some(*table_ref)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        changes.retain(|c| match c {
+            Change::DeleteTable { table_ref } => !created_tables.contains(&table_ref),
+            c => c
+                .affected_table_ref()
+                .map(|r| !deleted_tables.contains(&r))
+                .unwrap_or(true),
+        });
+
         Self { changes }
+    }
+
+    /// Whether this change set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
     }
 
     /// Compute the applied from the changes in this change set.
@@ -368,6 +407,27 @@ impl Change {
             | AddTableColumnTag { .. }
             | RemoveTableColumnTag { .. } => true,
             WriteTableDataFiles { .. } | WriteTableInlineData { .. } => false,
+        }
+    }
+
+    /// The TableRef which is affected by this change, if any.
+    fn affected_table_ref(&self) -> Option<TableRef> {
+        use Change::*;
+        match self {
+            CreateTable { table_ref, .. }
+            | RenameTable { table_ref, .. }
+            | UpdateTablePartitioning { table_ref, .. }
+            | DeleteTable { table_ref, .. }
+            | AddTableTag { table_ref, .. }
+            | RemoveTableTag { table_ref, .. }
+            | WriteTableDataFiles { table_ref, .. }
+            | WriteTableInlineData { table_ref, .. } => Some(*table_ref),
+            UpdateTableColumn { column_ref, .. }
+            | RemoveTableColumn { column_ref, .. }
+            | AddTableColumnTag { column_ref, .. }
+            | RemoveTableColumnTag { column_ref, .. } => Some(column_ref.table_ref),
+            AddTableColumn { column_refs, .. } => column_refs.first().map(|r| r.table_ref),
+            CreateSchema { .. } | DeleteSchema { .. } => None,
         }
     }
 

--- a/crates/ducklake/src/transaction/mod.rs
+++ b/crates/ducklake/src/transaction/mod.rs
@@ -113,14 +113,14 @@ impl<'a> Transaction<'a> {
 impl<'a> Transaction<'a> {
     /// Commit the transaction, persisting all changes as a new snapshot in the catalog.
     pub async fn commit(self) -> DucklakeResult<()> {
-        // If there were no changes, there's nothing to commit
-        if self.changes.is_empty() {
-            return Ok(());
-        }
-
-        // Otherwise, we initialize a changeset type which allows us to de-duplicate changes and
+        // First, we initialize a changeset type which allows us to de-duplicate changes and
         // provides high-level utilities.
         let change_set = ChangeSet::new(self.changes);
+
+        // If the change set is empty, there's nothing to commit
+        if change_set.is_empty() {
+            return Ok(());
+        }
 
         // To remedy conflicts caused by high-concurrency writes, we retry committing the
         // transaction. When retrying, we need to obtain the latest snapshot from the database.

--- a/crates/ducklake/src/transaction/schema.rs
+++ b/crates/ducklake/src/transaction/schema.rs
@@ -21,7 +21,7 @@ impl<'a> Transaction<'a> {
         let mut schema = self.catalog_mut().schema_mut(name)?;
         schema.delete()?;
         let change = Change::DeleteSchema {
-            schema_ref: schema.into(),
+            schema_ref: schema.ref_(),
         };
         self.changes.push(change);
         Ok(())

--- a/tests/differential/test_transaction.py
+++ b/tests/differential/test_transaction.py
@@ -31,3 +31,29 @@ def test_match_reference_table_double_rename_and_alter(
 
     # Assert
     assert_ducklake_catalogs_equal(reference_catalog_url, catalog_url)
+
+
+@pytest.mark.differential
+def test_match_reference_create_and_delete(
+    ducklake: dl.Ducklake,
+    catalog_url: str,
+    reference_catalog_url: str,
+    reference_duckdb_connection: duckdb.DuckDBPyConnection,
+) -> None:
+    # Act
+    with ducklake.transaction() as tx:
+        tx.create_table("test", {"x": dl.Int64()})
+        tx.table("test").rename("test2")
+        tx.table("test2").delete()
+
+    reference_duckdb_connection.execute(
+        """BEGIN;
+        CREATE TABLE test (x BIGINT);
+        ALTER TABLE test RENAME TO test2;
+        DROP TABLE test2;
+        COMMIT;
+        """
+    )
+
+    # Assert
+    assert_ducklake_catalogs_equal(reference_catalog_url, catalog_url)

--- a/tests/unit/transaction/test_table.py
+++ b/tests/unit/transaction/test_table.py
@@ -19,6 +19,35 @@ def test_create_table(shared_ducklake: dl.Ducklake, random_table_name: str) -> N
     assert table.tags == {}
 
 
+def test_create_delete_table_does_nothing(
+    shared_ducklake: dl.Ducklake, random_table_name: str
+) -> None:
+    # Arrange
+    snapshot = shared_ducklake.get_latest_snapshot()
+
+    # Act
+    with shared_ducklake.transaction() as tx:
+        tx.create_table(random_table_name, {"x": dl.Int64()})
+        tx.table(random_table_name).delete()
+
+    # Assert
+    assert shared_ducklake.get_latest_snapshot().id == snapshot.id
+
+
+def test_delete_create_table(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
+    # Arrange
+    shared_ducklake.create_table(random_table_name, {"x": dl.Int64()})
+
+    # Act
+    with shared_ducklake.transaction() as tx:
+        tx.table(random_table_name).delete()
+        tx.create_table(random_table_name, {"y": dl.Int64()})
+
+    # Assert
+    table = shared_ducklake.get_table(random_table_name)
+    assert table.schema.columns == [dl.Column("y", dl.Int64(), field_id=1)]
+
+
 def test_double_rename_keeps_last(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
     # Arrange
     table = shared_ducklake.create_table(random_table_name, {"x": dl.Int64()})


### PR DESCRIPTION
# Motivation

Currently, re-creating a table or dropping a created table within a transaction fails due to catalog and changeset limitations.
