### PR TITLE
chore: Fix `lefthook-install` task

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -34,7 +34,7 @@ ty = "*"
 typos = "*"
 
 [feature.lint.tasks]
-lefthook-install-py = "lefthook install-py pre-commit"
+lefthook-install = "lefthook install pre-commit"
 lint = "lefthook run pre-commit --all-files"
 lint-staged = "lefthook run pre-commit"
 


### PR DESCRIPTION
# Motivation

Accidentally introduced a typo here.
