### PR TITLE
fix: Correctly set table schema version

### DIFF
--- a/crates/ducklake/src/transaction/changes/change.rs
+++ b/crates/ducklake/src/transaction/changes/change.rs
@@ -467,18 +467,22 @@ impl Change {
             CreateTable { table_ref, .. }
             | RenameTable { table_ref, .. }
             | UpdateTablePartitioning { table_ref, .. }
-            | DeleteTable { table_ref, .. }
-            | AddTableTag { table_ref, .. }
-            | RemoveTableTag { table_ref, .. } => Some(*table_ref),
-            UpdateTableColumn { column_ref, .. }
-            | RemoveTableColumn { column_ref }
-            | AddTableColumnTag { column_ref, .. }
-            | RemoveTableColumnTag { column_ref, .. } => Some(column_ref.table_ref),
+            | DeleteTable { table_ref, .. } => Some(*table_ref),
+            UpdateTableColumn { column_ref, .. } | RemoveTableColumn { column_ref } => {
+                Some(column_ref.table_ref)
+            }
             AddTableColumn { column_refs, .. } => column_refs.first().map(|r| r.table_ref),
             CreateSchema { .. }
             | DeleteSchema { .. }
             | WriteTableDataFiles { .. }
-            | WriteTableInlineData { .. } => None,
+            | WriteTableInlineData { .. }
+            // NOTE: As opposed to `changes_schema` where we have to consider ALL items that
+            //  affect caching of the catalog, we do not want to consider changes that do not
+            //  affect the schema (i.e. how data is stored) of individual tables here.
+            | AddTableColumnTag { .. }
+            | RemoveTableColumnTag { .. }
+            | AddTableTag { .. }
+            | RemoveTableTag { .. } => None,
         }
     }
 

--- a/tests/differential/test_table.py
+++ b/tests/differential/test_table.py
@@ -21,6 +21,28 @@ def test_match_reference_table_creation(
 
 
 @pytest.mark.differential
+def test_match_reference_comment(
+    ducklake: dl.Ducklake,
+    catalog_url: str,
+    reference_catalog_url: str,
+    reference_duckdb_connection: duckdb.DuckDBPyConnection,
+) -> None:
+    # Act
+    table = ducklake.create_table("test", {"x": dl.Int64()})
+    table.add_tag("comment", "test")
+    table.update_partitioning(dl.Partitioning(["x"]))
+    table.rename("test_rename")
+
+    reference_duckdb_connection.execute("CREATE TABLE test (x BIGINT)")
+    reference_duckdb_connection.execute("COMMENT ON TABLE test IS 'test'")
+    reference_duckdb_connection.execute("ALTER TABLE test SET PARTITIONED BY (x)")
+    reference_duckdb_connection.execute("ALTER TABLE test RENAME TO test_rename")
+
+    # Assert
+    assert_ducklake_catalogs_equal(reference_catalog_url, catalog_url)
+
+
+@pytest.mark.differential
 def test_match_reference_nested_types(
     ducklake: dl.Ducklake,
     catalog_url: str,


### PR DESCRIPTION
# Motivation

Currently, we incorrectly bump a table's schema version when updating tags.
