### PR TITLE
style: Generate clippy warnings for `print_stdout`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,7 @@ strip = "symbols"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 unreachable_pub = "deny"
+
+[workspace.lints.clippy]
+print_stderr = "warn"
+print_stdout = "warn"

--- a/crates/ducklake/src/db/mod.rs
+++ b/crates/ducklake/src/db/mod.rs
@@ -427,6 +427,7 @@ impl Transaction {
 
 /* ------------------------------------------- UTILS ------------------------------------------- */
 
+#[allow(clippy::print_stdout)]
 fn log_sql(sql: &str, values: Option<&sea_query_sqlx::SqlxValues>) {
     static VERBOSE: OnceLock<bool> = OnceLock::new();
     let verbose =


### PR DESCRIPTION
# Motivation

Catch unintended prints in CI.
