### PR TITLE
chore: Use stable `arrow-rs` release instead of git rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,8 +80,9 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arrow-arith"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -93,8 +94,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -112,8 +114,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
  "bytes",
  "half",
@@ -123,8 +126,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -144,8 +148,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -156,8 +161,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -169,8 +175,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -181,8 +188,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
 dependencies = [
  "bitflags",
  "serde",
@@ -192,8 +200,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -1702,8 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "59.1.0"
-source = "git+https://github.com/apache/arrow-rs?rev=ed92960c8a85eda657fce3525c905616ccc5a983#ed92960c8a85eda657fce3525c905616ccc5a983"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ members = ["crates/ducklake", "crates/ducklake-macros", "ducklake-python"]
 resolver = "2"
 
 [workspace.dependencies]
-arrow-arith = "59.0"
-arrow-array = "59.0"
-arrow-schema = "59.0"
+arrow-arith = "59.2"
+arrow-array = "59.2"
+arrow-schema = "59.2"
 async-recursion = "1.1"
 bytes = "1.12"
 chrono = "0.4"
@@ -15,7 +15,7 @@ hex = "0.4"
 indexmap = "2.14"
 itertools = "0.15"
 object_store = "0.13"
-parquet = "59.0"
+parquet = "59.2"
 percent-encoding = "2.3"
 proc-macro2 = "1.0"
 pyo3 = "0.28"
@@ -38,18 +38,6 @@ uuid = "1.23"
 
 ducklake = { path = "crates/ducklake", version = "0.0.0" }
 ducklake-macros = { path = "crates/ducklake-macros", version = "0.0.0" }
-
-# FIXME: Temporarily override arrow-rs with main until https://github.com/apache/arrow-rs/pull/10514 is released
-[patch.crates-io]
-arrow-arith = { git = "https://github.com/apache/arrow-rs", rev = "ed92960c8a85eda657fce3525c905616ccc5a983" }
-arrow-array = { git = "https://github.com/apache/arrow-rs", rev = "ed92960c8a85eda657fce3525c905616ccc5a983" }
-arrow-buffer = { git = "https://github.com/apache/arrow-rs", rev = "ed92960c8a85eda657fce3525c905616ccc5a983" }
-arrow-cast = { git = "https://github.com/apache/arrow-rs", rev = "ed92960c8a85eda657fce3525c905616ccc5a983" }
-arrow-data = { git = "https://github.com/apache/arrow-rs", rev = "ed92960c8a85eda657fce3525c905616ccc5a983" }
-arrow-ord = { git = "https://github.com/apache/arrow-rs", rev = "ed92960c8a85eda657fce3525c905616ccc5a983" }
-arrow-schema = { git = "https://github.com/apache/arrow-rs", rev = "ed92960c8a85eda657fce3525c905616ccc5a983" }
-arrow-select = { git = "https://github.com/apache/arrow-rs", rev = "ed92960c8a85eda657fce3525c905616ccc5a983" }
-parquet = { git = "https://github.com/apache/arrow-rs", rev = "ed92960c8a85eda657fce3525c905616ccc5a983" }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
# Motivation

59.2.0 has been released with the relevant bugfix.
