### PR TITLE
feat: Allow to directly write data files from Python

### DIFF
--- a/ducklake-python/ducklake/polars/sink.py
+++ b/ducklake-python/ducklake/polars/sink.py
@@ -253,4 +253,4 @@ def _sinked_paths_callback(
         )
         new_data_files.append(data_file)
 
-    table._write_data_files(new_data_files)
+    table.write_data_files(new_data_files)

--- a/ducklake-python/ducklake/table.py
+++ b/ducklake-python/ducklake/table.py
@@ -108,21 +108,23 @@ class Table:
         """Scan the table and return all data files with their associated delete files."""
         return self._pytable.scan()
 
-    def write_data_files(self, files: Sequence[str | WriteDataFile]) -> None:
+    def write_data_files(self, files: str | WriteDataFile | Sequence[str | WriteDataFile]) -> None:
         """Register existing Parquet files with the table without rewriting them.
 
         Args:
-            files: The data files to add. Each entry may either be a path to a Parquet file or a
-                :class:`WriteDataFile` for full control over statistics and partition values. Paths
-                may be relative to the table's data path or absolute (including remote URLs such as
-                ``s3://``).
+            files: The data files to add. This may be a single file or a sequence of files. Each
+                entry may either be a path to a Parquet file or a :class:`WriteDataFile` for full
+                control over statistics and partition values. Paths may be relative to the table's
+                data path or absolute (including remote URLs such as ``s3://``).
 
         Note:
             For any file whose statistics are not provided, the statistics are computed by reading
-            the file's Parquet footer when committing. Ownership of the added files is transferred
-            to DuckLake, i.e. they may be deleted by subsequent maintenance operations and must not
-            be modified externally.
+            the file's Parquet footer while registering the file. Ownership of the added files is
+            transferred to DuckLake, i.e. they may be deleted by subsequent maintenance operations
+            and must not be modified externally.
         """
+        if isinstance(files, (str, WriteDataFile)):
+            files = [files]
         self._pytable.write_data_files(
             [WriteDataFile(f) if isinstance(f, str) else f for f in files]
         )

--- a/ducklake-python/ducklake/table.py
+++ b/ducklake-python/ducklake/table.py
@@ -108,11 +108,27 @@ class Table:
         """Scan the table and return all data files with their associated delete files."""
         return self._pytable.scan()
 
+    def write_data_files(self, files: Sequence[str | WriteDataFile]) -> None:
+        """Register existing Parquet files with the table without rewriting them.
+
+        Args:
+            files: The data files to add. Each entry may either be a path to a Parquet file or a
+                :class:`WriteDataFile` for full control over statistics and partition values. Paths
+                may be relative to the table's data path or absolute (including remote URLs such as
+                ``s3://``).
+
+        Note:
+            For any file whose statistics are not provided, the statistics are computed by reading
+            the file's Parquet footer when committing. Ownership of the added files is transferred
+            to DuckLake, i.e. they may be deleted by subsequent maintenance operations and must not
+            be modified externally.
+        """
+        self._pytable.write_data_files(
+            [WriteDataFile(f) if isinstance(f, str) else f for f in files]
+        )
+
     def _get_write_info(self) -> tuple[TableMetadata, PyDataFilePathGenerator]:
         return self._pytable.get_write_info()
-
-    def _write_data_files(self, new_data_files: list[WriteDataFile]) -> None:
-        self._pytable.write_data_files(new_data_files)
 
     def _write_inline_data(self, data: ArrowStreamExportable) -> None:
         self._pytable.write_inline_data(data)

--- a/ducklake-python/ducklake/transaction.py
+++ b/ducklake-python/ducklake/transaction.py
@@ -166,11 +166,27 @@ class TransactionTable:
     #                                            WRITES                                           #
     # ------------------------------------------------------------------------------------------- #
 
+    def write_data_files(self, files: Sequence[str | WriteDataFile]) -> None:
+        """Register existing Parquet files with the table without rewriting them.
+
+        Args:
+            files: The data files to add. Each entry may either be a path to a Parquet file or a
+                :class:`WriteDataFile` for full control over statistics and partition values. Paths
+                may be relative to the table's data path or absolute (including remote URLs such as
+                ``s3://``).
+
+        Note:
+            For any file whose statistics are not provided, the statistics are computed by reading
+            the file's Parquet footer when committing. Ownership of the added files is transferred
+            to DuckLake, i.e. they may be deleted by subsequent maintenance operations and must not
+            be modified externally.
+        """
+        self._pytxtable.write_data_files(
+            [WriteDataFile(f) if isinstance(f, str) else f for f in files]
+        )
+
     def _get_write_info(self) -> tuple[TableMetadata, PyDataFilePathGenerator]:
         return self._pytxtable.get_write_info()
-
-    def _write_data_files(self, new_data_files: list[WriteDataFile]) -> None:
-        self._pytxtable.write_data_files(new_data_files)
 
     def _write_inline_data(self, data: ArrowStreamExportable) -> None:
         self._pytxtable.write_inline_data(data)

--- a/ducklake-python/ducklake/transaction.py
+++ b/ducklake-python/ducklake/transaction.py
@@ -166,21 +166,23 @@ class TransactionTable:
     #                                            WRITES                                           #
     # ------------------------------------------------------------------------------------------- #
 
-    def write_data_files(self, files: Sequence[str | WriteDataFile]) -> None:
+    def write_data_files(self, files: str | WriteDataFile | Sequence[str | WriteDataFile]) -> None:
         """Register existing Parquet files with the table without rewriting them.
 
         Args:
-            files: The data files to add. Each entry may either be a path to a Parquet file or a
-                :class:`WriteDataFile` for full control over statistics and partition values. Paths
-                may be relative to the table's data path or absolute (including remote URLs such as
-                ``s3://``).
+            files: The data files to add. This may be a single file or a sequence of files. Each
+                entry may either be a path to a Parquet file or a :class:`WriteDataFile` for full
+                control over statistics and partition values. Paths may be relative to the table's
+                data path or absolute (including remote URLs such as ``s3://``).
 
         Note:
             For any file whose statistics are not provided, the statistics are computed by reading
-            the file's Parquet footer when committing. Ownership of the added files is transferred
-            to DuckLake, i.e. they may be deleted by subsequent maintenance operations and must not
-            be modified externally.
+            the file's Parquet footer while registering the file. Ownership of the added files is
+            transferred to DuckLake, i.e. they may be deleted by subsequent maintenance operations
+            and must not be modified externally.
         """
+        if isinstance(files, (str, WriteDataFile)):
+            files = [files]
         self._pytxtable.write_data_files(
             [WriteDataFile(f) if isinstance(f, str) else f for f in files]
         )

--- a/tests/unit/table/test_write_data_files.py
+++ b/tests/unit/table/test_write_data_files.py
@@ -1,0 +1,96 @@
+import os
+
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+import ducklake as dl
+
+pytestmark = pytest.mark.skip_config(
+    storage="s3", reason="Local Parquet files are written to the storage path."
+)
+
+
+def _write_parquet(table: dl.Table, name: str, data: dict) -> str:
+    _, generator = table._get_write_info()
+    path = os.path.join(generator.base_path, name)
+    pl.DataFrame(data).write_parquet(
+        path,
+        arrow_schema=table.schema,
+        storage_options=table._storage_options.to_dict(),
+        mkdir=True,
+    )
+    return name
+
+
+def test_write_data_files_from_paths(ducklake: dl.Ducklake, random_table_name: str) -> None:
+    # Arrange
+    table = ducklake.create_table(random_table_name, {"x": dl.Int64()})
+    path = _write_parquet(table, "file.parquet", {"x": [1, 2, 3]})
+
+    # Act
+    table.write_data_files([path])
+
+    # Assert
+    assert table.scan().data_files[0].statistics.num_rows == 3
+    assert_frame_equal(
+        table.scan_polars().sort("x"),
+        pl.LazyFrame({"x": [1, 2, 3]}, schema={"x": pl.Int64}),
+    )
+
+
+def test_write_data_files_with_statistics(ducklake: dl.Ducklake, random_table_name: str) -> None:
+    # Arrange
+    table = ducklake.create_table(random_table_name, {"x": dl.Int64()})
+    path = _write_parquet(table, "file.parquet", {"x": [1, 2, 3]})
+
+    # Act
+    table.write_data_files(
+        [
+            dl.WriteDataFile(
+                path,
+                statistics=dl.DataFileStatistics(
+                    num_rows=3,
+                    column_stats={1: dl.ColumnStats(min_value=1, max_value=3, null_count=0)},
+                ),
+            )
+        ]
+    )
+
+    # Assert
+    stats = table.scan().data_files[0].statistics
+    assert stats.num_rows == 3
+    assert stats.column_stats[1].min_value == 1
+    assert stats.column_stats[1].max_value == 3
+
+
+def test_write_data_files_mixed(ducklake: dl.Ducklake, random_table_name: str) -> None:
+    # Arrange
+    table = ducklake.create_table(random_table_name, {"x": dl.Int64()})
+    path_a = _write_parquet(table, "a.parquet", {"x": [1, 2, 3]})
+    path_b = _write_parquet(table, "b.parquet", {"x": [4, 5, 6]})
+
+    # Act
+    table.write_data_files([path_a, dl.WriteDataFile(path_b)])
+
+    # Assert
+    assert_frame_equal(
+        table.scan_polars().sort("x"),
+        pl.LazyFrame({"x": [1, 2, 3, 4, 5, 6]}, schema={"x": pl.Int64}),
+    )
+
+
+def test_write_data_files_in_transaction(ducklake: dl.Ducklake, random_table_name: str) -> None:
+    # Arrange
+    table = ducklake.create_table(random_table_name, {"x": dl.Int64()})
+    path = _write_parquet(table, "file.parquet", {"x": [1, 2, 3]})
+
+    # Act
+    with ducklake.transaction() as tx:
+        tx.table(random_table_name).write_data_files([path])
+
+    # Assert
+    assert_frame_equal(
+        ducklake.get_table(random_table_name).scan_polars().sort("x"),
+        pl.LazyFrame({"x": [1, 2, 3]}, schema={"x": pl.Int64}),
+    )


### PR DESCRIPTION
# Motivation

Implement [`ducklake_add_data_files`](https://ducklake.select/docs/stable/duckdb/metadata/adding_files).
