### PR TITLE
fix: Hide connection password when printing ducklakes

### DIFF
--- a/ducklake-python/ducklake/connect.py
+++ b/ducklake-python/ducklake/connect.py
@@ -177,19 +177,23 @@ class ConnectionArgs:
         This is different to the Python string representation as Rust's sqlx uses one slash fewer
         for SQLite URLs.
         """
-        result = str(self)
+        result = self._render_url(hide_password=False)
         if self.dialect == "sqlite":
             result = result.replace("sqlite:///", "sqlite://", 1)
         return result
 
     def __str__(self) -> str:
+        return self._render_url()
+
+    def _render_url(self, *, hide_password: bool = True) -> str:
         match self.dialect:
             case "postgresql" | "mysql":
                 url = self.dialect + "://"
                 if self.username is not None:
                     url += quote(self.username, safe=" +")
                     if self.password is not None:
-                        url += ":" + quote(str(self.password), safe=" +")
+                        password = "***" if hide_password else quote(str(self.password), safe=" +")
+                        url += ":" + password
                     url += "@"
                 if self.host is not None:
                     if ":" in self.host:

--- a/ducklake-python/ducklake/connect.py
+++ b/ducklake-python/ducklake/connect.py
@@ -177,15 +177,15 @@ class ConnectionArgs:
         This is different to the Python string representation as Rust's sqlx uses one slash fewer
         for SQLite URLs.
         """
-        result = self._render_url(hide_password=False)
+        result = self.render_as_string(hide_password=False)
         if self.dialect == "sqlite":
             result = result.replace("sqlite:///", "sqlite://", 1)
         return result
 
     def __str__(self) -> str:
-        return self._render_url()
+        return self.render_as_string()
 
-    def _render_url(self, *, hide_password: bool = True) -> str:
+    def render_as_string(self, *, hide_password: bool = True) -> str:
         match self.dialect:
             case "postgresql" | "mysql":
                 url = self.dialect + "://"

--- a/tests/unit/ducklake/test_connect.py
+++ b/tests/unit/ducklake/test_connect.py
@@ -44,12 +44,30 @@ def test_fail_connect_when_not_created(catalog_url: str) -> None:
         dl.connect(catalog_url)
 
 
-def test_ducklake_repr(ducklake: dl.Ducklake, catalog_url: str) -> None:
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("sqlite:///path/to/db.db", 'Ducklake(url="sqlite:///path/to/db.db")'),
+        (
+            "postgresql://user:secret@localhost:5432/db",
+            'Ducklake(url="postgresql://user:***@localhost:5432/db")',
+        ),
+        (
+            "mysql://user:p%40ss@localhost:3306/db",
+            'Ducklake(url="mysql://user:***@localhost:3306/db")',
+        ),
+    ],
+)
+def test_ducklake_repr(url: str, expected: str) -> None:
+    # Arrange
+    ducklake = dl.Ducklake.__new__(dl.Ducklake)
+    ducklake._connection_args = _sanitize_url(url)
+
     # Act
     actual = repr(ducklake)
 
     # Assert
-    assert actual == f'Ducklake(url="{catalog_url}")'
+    assert actual == expected
 
 
 def test_data_path(catalog: str, tmp_path: Path) -> None:
@@ -74,25 +92,31 @@ def test_data_path(catalog: str, tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "url",
+    ("url", "expected"),
     [
-        "sqlite:///path/to/db.db",
-        "sqlite:///path/to/db.db?mode=ro",
-        "postgresql://localhost",
-        "postgresql://user@localhost",
-        "postgresql://user:pass@localhost:5432/db",
-        "postgresql://user:pass@localhost:5432/db?sslmode=require",
-        "mysql://user:pass@localhost:3306/db",
-        "postgresql://[::1]:5432/db",
+        ("sqlite:///path/to/db.db", "sqlite:///path/to/db.db"),
+        ("sqlite:///path/to/db.db?mode=ro", "sqlite:///path/to/db.db?mode=ro"),
+        ("postgresql://localhost", "postgresql://localhost"),
+        ("postgresql://user@localhost", "postgresql://user@localhost"),
+        (
+            "postgresql://user:pass@localhost:5432/db",
+            "postgresql://user:***@localhost:5432/db",
+        ),
+        (
+            "postgresql://user:pass@localhost:5432/db?sslmode=require",
+            "postgresql://user:***@localhost:5432/db?sslmode=require",
+        ),
+        ("mysql://user:pass@localhost:3306/db", "mysql://user:***@localhost:3306/db"),
+        ("postgresql://[::1]:5432/db", "postgresql://[::1]:5432/db"),
     ],
 )
-def test_connection_args_url_roundtrip(url: str) -> None:
+def test_connection_args_str(url: str, expected: str) -> None:
     # Act
     args = _sanitize_url(url)
     actual = str(args)
 
     # Assert
-    assert actual == url
+    assert actual == expected
 
 
 def test_connection_args_supports_dialect_with_driver() -> None:

--- a/tests/unit/ducklake/test_readonly.py
+++ b/tests/unit/ducklake/test_readonly.py
@@ -90,6 +90,7 @@ def test_readonly_allows_reads(shared_ducklake: dl.Ducklake, random_table_name: 
     assert random_table_name in [table.name[1] for table in readonly.list_tables()]
 
 
+@pytest.mark.skip_config(catalog="mysql", reason="The DuckDB MySQL connector is unreliable.")
 def test_readonly_blocks_duckdb_write(
     shared_ducklake: dl.Ducklake, random_table_name: str
 ) -> None:

--- a/tests/unit/polars/test_write.py
+++ b/tests/unit/polars/test_write.py
@@ -48,14 +48,18 @@ def test_sink_parquet(shared_ducklake: dl.Ducklake, random_table_name: str) -> N
     )
 
     # -- Table stats
-    table_stats = read_table_stats(str(shared_ducklake._connection_args), random_table_name)
+    table_stats = read_table_stats(
+        shared_ducklake._connection_args.render_as_string(hide_password=False),
+        random_table_name,
+    )
     assert table_stats["record_count"] == 100
     assert table_stats["next_row_id"] == 100
     assert table_stats["file_size_bytes"] == data_file.statistics.file_size_bytes
 
     # -- Table column stats
     table_column_stats = read_table_column_stats(
-        str(shared_ducklake._connection_args), random_table_name
+        shared_ducklake._connection_args.render_as_string(hide_password=False),
+        random_table_name,
     )
     assert table_column_stats[1]["min_value"] == "0"
     assert table_column_stats[1]["max_value"] == "99"

--- a/tests/unit/polars/test_write.py
+++ b/tests/unit/polars/test_write.py
@@ -103,14 +103,18 @@ def test_write_parquet_inline(shared_ducklake: dl.Ducklake, random_table_name: s
     assert_frame_equal(df, pl.DataFrame(scan_result.inline_data[0]))
 
     # -- Table stats
-    table_stats = read_table_stats(str(shared_ducklake._connection_args), random_table_name)
+    table_stats = read_table_stats(
+        shared_ducklake._connection_args.render_as_string(hide_password=False),
+        random_table_name,
+    )
     assert table_stats["record_count"] == num_rows
     assert table_stats["next_row_id"] == num_rows
     assert table_stats["file_size_bytes"] == 0
 
     # -- Table column stats
     table_column_stats = read_table_column_stats(
-        str(shared_ducklake._connection_args), random_table_name
+        shared_ducklake._connection_args.render_as_string(hide_password=False),
+        random_table_name,
     )
     assert table_column_stats[1]["min_value"] == "0"
     assert table_column_stats[1]["max_value"] == f"{num_rows - 1}"


### PR DESCRIPTION
# Motivation

Printing ducklakes currently exposes the connection string's password.
