### PR TITLE
fix: Normalize Arrow list element names

### DIFF
--- a/crates/ducklake/src/typedefs/schema/arrow.rs
+++ b/crates/ducklake/src/typedefs/schema/arrow.rs
@@ -175,7 +175,8 @@ impl TryFrom<&ArrowField> for Column {
                 Ok(DataType::uuid())
             }
             ArrowDataType::List(inner) | ArrowDataType::LargeList(inner) => {
-                let inner_type = Column::try_from(&**inner)?;
+                let mut inner_type = Column::try_from(&**inner)?;
+                inner_type.name = "element".to_string();
                 Ok(DataType::List(Box::new(inner_type)))
             }
             ArrowDataType::Struct(fields) => {

--- a/tests/unit/test_typedefs.py
+++ b/tests/unit/test_typedefs.py
@@ -62,10 +62,12 @@ def test_schema_from_arrow() -> None:
     ]
 
 
-def test_schema_from_arrow_renames_list_element() -> None:
+@pytest.mark.parametrize("list_factory_name", ["list_", "large_list"])
+def test_schema_from_arrow_renames_list_element(list_factory_name: str) -> None:
     # Arrange
     pa = pytest.importorskip("pyarrow")
-    arrow_schema = pa.schema({"values": pa.list_(pa.field("item", pa.int64()))})
+    list_factory = getattr(pa, list_factory_name)
+    arrow_schema = pa.schema({"values": list_factory(pa.field("item", pa.int64()))})
 
     # Act
     schema = dl.Schema(arrow_schema)

--- a/tests/unit/test_typedefs.py
+++ b/tests/unit/test_typedefs.py
@@ -62,6 +62,18 @@ def test_schema_from_arrow() -> None:
     ]
 
 
+def test_schema_from_arrow_renames_list_element() -> None:
+    # Arrange
+    pa = pytest.importorskip("pyarrow")
+    arrow_schema = pa.schema({"values": pa.list_(pa.field("item", pa.int64()))})
+
+    # Act
+    schema = dl.Schema(arrow_schema)
+
+    # Assert
+    assert schema.columns == [dl.Column("values", dl.List(dl.Int64()))]
+
+
 def test_schema_from_polars_enum() -> None:
     # Arrange
     polars_schema = pl.Schema({"e": pl.Enum(["a", "b", "c"])})


### PR DESCRIPTION
# Motivation

PyArrow list fields commonly name their inner field `item`, which caused DuckLake schema creation through Arrow PyCapsules to fail because DuckLake requires `element`.

# Changes

- Normalize Arrow `List` and `LargeList` inner field names to `element` during conversion.
- Add a PyArrow regression test.
- Verify Python typedef tests, Rust schema tests, formatting, and linting.
