### PR TITLE
fix: Properly support nested columns for the Arrow PyCapsule interface

### DIFF
--- a/crates/ducklake/src/typedefs/schema/arrow.rs
+++ b/crates/ducklake/src/typedefs/schema/arrow.rs
@@ -30,6 +30,14 @@ impl Schema {
 
 impl Column {
     pub fn to_arrow_field(&self) -> ArrowField {
+        self.to_arrow_field_with(&Column::to_arrow_field)
+    }
+
+    #[doc(hidden)]
+    pub fn to_arrow_field_with(
+        &self,
+        convert_child: &impl Fn(&Column) -> ArrowField,
+    ) -> ArrowField {
         const PARQUET_FIELD_ID_KEY: &str = "PARQUET:field_id";
 
         let data_type = match &self.dtype {
@@ -65,15 +73,15 @@ impl Column {
             DataType::Blob => ArrowDataType::LargeBinary,
             DataType::Json => ArrowDataType::Utf8View,
             DataType::Uuid => ArrowDataType::FixedSizeBinary(16),
-            DataType::List(inner) => ArrowDataType::LargeList(Arc::new(inner.to_arrow_field())),
+            DataType::List(inner) => ArrowDataType::LargeList(Arc::new(convert_child(inner))),
             DataType::Struct(fields) => {
-                let fields = fields.iter().map(|f| f.to_arrow_field()).collect();
+                let fields = fields.iter().map(convert_child).collect();
                 ArrowDataType::Struct(fields)
             }
             DataType::Map(key, value) => {
                 let entries = ArrowField::new_struct(
                     "entries",
-                    vec![key.to_arrow_field(), value.to_arrow_field()],
+                    vec![convert_child(key), convert_child(value)],
                     false,
                 );
                 ArrowDataType::Map(Arc::new(entries), false)
@@ -118,10 +126,12 @@ impl From<TimestampPrecision> for ArrowTimeUnit {
 
 /* -------------------------------------- ARROW -> COLUMN -------------------------------------- */
 
-impl TryFrom<&ArrowField> for Column {
-    type Error = DucklakeError;
-
-    fn try_from(field: &ArrowField) -> Result<Self, Self::Error> {
+impl Column {
+    #[doc(hidden)]
+    pub fn try_from_arrow_field_with(
+        field: &ArrowField,
+        convert_child: &impl Fn(&ArrowField) -> Result<Column, DucklakeError>,
+    ) -> Result<Self, DucklakeError> {
         let dtype = match field.data_type() {
             ArrowDataType::Boolean => Ok(DataType::boolean()),
             ArrowDataType::Int8 => Ok(DataType::int8()),
@@ -175,29 +185,22 @@ impl TryFrom<&ArrowField> for Column {
                 Ok(DataType::uuid())
             }
             ArrowDataType::List(inner) | ArrowDataType::LargeList(inner) => {
-                let mut inner_type = Column::try_from(&**inner)?;
+                let mut inner_type = convert_child(inner)?;
                 inner_type.name = "element".to_string();
                 Ok(DataType::List(Box::new(inner_type)))
             }
-            ArrowDataType::Struct(fields) => {
-                let mut columns = Vec::with_capacity(fields.len());
-                for field in fields {
-                    let column = Column::try_from(&**field)?;
-                    columns.push(column);
-                }
-                Ok(DataType::struct_(
-                    fields
-                        .iter()
-                        .map(|f| Column::try_from(&**f))
-                        .try_collect()?,
-                ))
-            }
+            ArrowDataType::Struct(fields) => Ok(DataType::struct_(
+                fields
+                    .iter()
+                    .map(|field| convert_child(field))
+                    .try_collect()?,
+            )),
             ArrowDataType::Map(entries, _) => {
                 let ArrowDataType::Struct(fields) = entries.data_type() else {
                     panic!("map entries field must have a struct data type")
                 };
-                let key_type = Column::try_from(&*fields[0])?;
-                let value_type = Column::try_from(&*fields[1])?;
+                let key_type = convert_child(&fields[0])?;
+                let value_type = convert_child(&fields[1])?;
                 Ok(DataType::Map(Box::new(key_type), Box::new(value_type)))
             }
             other => Err(DucklakeError::UnsupportedArrowDataType(format!(
@@ -216,5 +219,13 @@ impl TryFrom<&ArrowField> for Column {
                 .get(PARQUET_FIELD_ID_META_KEY)
                 .and_then(|id_str| id_str.parse().ok()),
         })
+    }
+}
+
+impl TryFrom<&ArrowField> for Column {
+    type Error = DucklakeError;
+
+    fn try_from(field: &ArrowField) -> Result<Self, Self::Error> {
+        Self::try_from_arrow_field_with(field, &|field| Column::try_from(field))
     }
 }

--- a/ducklake-python/src/utils/arrow.rs
+++ b/ducklake-python/src/utils/arrow.rs
@@ -41,24 +41,7 @@ pub(crate) fn schema_to_arrow(columns: Vec<Wrap<ducklake::Column>>) -> PyResult<
 
 fn arrow_field_from_column(column: &ducklake::Column) -> Field {
     // First, we translate the column into its direct Arrow representation
-    let field = column.to_arrow_field();
-    let field = match &column.dtype {
-        ducklake::DataType::List(inner) => field.with_data_type(ArrowDataType::LargeList(
-            Arc::new(arrow_field_from_column(inner)),
-        )),
-        ducklake::DataType::Struct(fields) => field.with_data_type(ArrowDataType::Struct(
-            fields.iter().map(arrow_field_from_column).collect(),
-        )),
-        ducklake::DataType::Map(key, value) => {
-            let entries = Field::new_struct(
-                "entries",
-                vec![arrow_field_from_column(key), arrow_field_from_column(value)],
-                false,
-            );
-            field.with_data_type(ArrowDataType::Map(Arc::new(entries), false))
-        }
-        _ => field,
-    };
+    let field = column.to_arrow_field_with(&arrow_field_from_column);
 
     // Then, we check for the comment tag to see if we need to attach metadata and/or convert to
     // a dictionary type
@@ -105,41 +88,15 @@ fn column_from_arrow_field(field: &Field) -> DucklakeResult<ducklake::Column> {
         ArrowDataType::Dictionary(_, value_type) => {
             let original_dtype = (field.data_type().clone(), field.dict_is_ordered().unwrap());
             let field = field.clone().with_data_type((**value_type).clone());
-            (ducklake::Column::try_from(&field)?, Some(original_dtype))
-        }
-        ArrowDataType::List(inner) | ArrowDataType::LargeList(inner) => {
-            let mut inner = column_from_arrow_field(inner)?;
-            inner.name = "element".to_string();
             (
-                nested_column_from_arrow_field(field, ducklake::DataType::List(Box::new(inner))),
-                None,
+                ducklake::Column::try_from_arrow_field_with(&field, &column_from_arrow_field)?,
+                Some(original_dtype),
             )
         }
-        ArrowDataType::Struct(fields) => {
-            let fields = fields
-                .iter()
-                .map(|field| column_from_arrow_field(field))
-                .collect::<Result<Vec<_>, _>>()?;
-            (
-                nested_column_from_arrow_field(field, ducklake::DataType::Struct(fields)),
-                None,
-            )
-        }
-        ArrowDataType::Map(entries, _) => {
-            let ArrowDataType::Struct(fields) = entries.data_type() else {
-                panic!("map entries field must have a struct data type")
-            };
-            let key = column_from_arrow_field(&fields[0])?;
-            let value = column_from_arrow_field(&fields[1])?;
-            (
-                nested_column_from_arrow_field(
-                    field,
-                    ducklake::DataType::Map(Box::new(key), Box::new(value)),
-                ),
-                None,
-            )
-        }
-        _ => (ducklake::Column::try_from(field)?, None),
+        _ => (
+            ducklake::Column::try_from_arrow_field_with(field, &column_from_arrow_field)?,
+            None,
+        ),
     };
 
     // In any case, we persist field metadata if there is any
@@ -155,20 +112,6 @@ fn column_from_arrow_field(field: &Field) -> DucklakeResult<ducklake::Column> {
         });
     }
     Ok(column)
-}
-
-fn nested_column_from_arrow_field(
-    field: &Field,
-    data_type: ducklake::DataType,
-) -> ducklake::Column {
-    ducklake::Column::new(field.name().clone(), data_type)
-        .nullable(field.is_nullable())
-        .field_id(
-            field
-                .metadata()
-                .get(PARQUET_FIELD_ID_META_KEY)
-                .and_then(|id| id.parse().ok()),
-        )
 }
 
 /* ----------------------------------------- FIELD IDS ----------------------------------------- */

--- a/ducklake-python/src/utils/arrow.rs
+++ b/ducklake-python/src/utils/arrow.rs
@@ -42,6 +42,23 @@ pub(crate) fn schema_to_arrow(columns: Vec<Wrap<ducklake::Column>>) -> PyResult<
 fn arrow_field_from_column(column: &ducklake::Column) -> Field {
     // First, we translate the column into its direct Arrow representation
     let field = column.to_arrow_field();
+    let field = match &column.dtype {
+        ducklake::DataType::List(inner) => field.with_data_type(ArrowDataType::LargeList(
+            Arc::new(arrow_field_from_column(inner)),
+        )),
+        ducklake::DataType::Struct(fields) => field.with_data_type(ArrowDataType::Struct(
+            fields.iter().map(arrow_field_from_column).collect(),
+        )),
+        ducklake::DataType::Map(key, value) => {
+            let entries = Field::new_struct(
+                "entries",
+                vec![arrow_field_from_column(key), arrow_field_from_column(value)],
+                false,
+            );
+            field.with_data_type(ArrowDataType::Map(Arc::new(entries), false))
+        }
+        _ => field,
+    };
 
     // Then, we check for the comment tag to see if we need to attach metadata and/or convert to
     // a dictionary type
@@ -90,6 +107,38 @@ fn column_from_arrow_field(field: &Field) -> DucklakeResult<ducklake::Column> {
             let field = field.clone().with_data_type((**value_type).clone());
             (ducklake::Column::try_from(&field)?, Some(original_dtype))
         }
+        ArrowDataType::List(inner) | ArrowDataType::LargeList(inner) => {
+            let mut inner = column_from_arrow_field(inner)?;
+            inner.name = "element".to_string();
+            (
+                nested_column_from_arrow_field(field, ducklake::DataType::List(Box::new(inner))),
+                None,
+            )
+        }
+        ArrowDataType::Struct(fields) => {
+            let fields = fields
+                .iter()
+                .map(|field| column_from_arrow_field(field))
+                .collect::<Result<Vec<_>, _>>()?;
+            (
+                nested_column_from_arrow_field(field, ducklake::DataType::Struct(fields)),
+                None,
+            )
+        }
+        ArrowDataType::Map(entries, _) => {
+            let ArrowDataType::Struct(fields) = entries.data_type() else {
+                panic!("map entries field must have a struct data type")
+            };
+            let key = column_from_arrow_field(&fields[0])?;
+            let value = column_from_arrow_field(&fields[1])?;
+            (
+                nested_column_from_arrow_field(
+                    field,
+                    ducklake::DataType::Map(Box::new(key), Box::new(value)),
+                ),
+                None,
+            )
+        }
         _ => (ducklake::Column::try_from(field)?, None),
     };
 
@@ -106,6 +155,20 @@ fn column_from_arrow_field(field: &Field) -> DucklakeResult<ducklake::Column> {
         });
     }
     Ok(column)
+}
+
+fn nested_column_from_arrow_field(
+    field: &Field,
+    data_type: ducklake::DataType,
+) -> ducklake::Column {
+    ducklake::Column::new(field.name().clone(), data_type)
+        .nullable(field.is_nullable())
+        .field_id(
+            field
+                .metadata()
+                .get(PARQUET_FIELD_ID_META_KEY)
+                .and_then(|id| id.parse().ok()),
+        )
 }
 
 /* ----------------------------------------- FIELD IDS ----------------------------------------- */

--- a/tests/unit/test_typedefs.py
+++ b/tests/unit/test_typedefs.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any
 
 import polars as pl
@@ -124,6 +125,30 @@ def test_schema_polars_metadata_round_trip(polars_schema: pl.Schema) -> None:
 
     # Assert
     assert round_trip == polars_schema
+
+
+@pytest.mark.parametrize(
+    "nested_type_factory",
+    [
+        lambda pa, dtype: pa.large_list(pa.field("element", dtype, metadata={"kind": "enum"})),
+        lambda pa, dtype: pa.struct([pa.field("value", dtype, metadata={"kind": "enum"})]),
+        lambda pa, dtype: pa.map_(pa.int64(), pa.field("value", dtype, metadata={"kind": "enum"})),
+    ],
+    ids=["list", "struct", "map"],
+)
+def test_schema_arrow_metadata_round_trip_for_nested_dictionary(
+    nested_type_factory: Callable[[Any, Any], Any],
+) -> None:
+    # Arrange
+    pa = pytest.importorskip("pyarrow")
+    dictionary_type = pa.dictionary(pa.uint8(), pa.string())
+    arrow_schema = pa.schema({"nested": nested_type_factory(pa, dictionary_type)})
+
+    # Act
+    round_trip = pa.schema(dl.Schema(arrow_schema))
+
+    # Assert
+    assert round_trip.equals(arrow_schema, check_metadata=True)
 
 
 # ------------------------------------------- COLUMN -------------------------------------------- #

--- a/tests/unit/test_typedefs.py
+++ b/tests/unit/test_typedefs.py
@@ -111,6 +111,7 @@ def test_schema_from_polars_categorical() -> None:
     [
         pl.Schema({"e": pl.Enum(["a", "b", "c"])}),
         pl.Schema({"c": pl.Categorical()}),
+        pl.Schema({"e": pl.List(pl.Enum(["a", "b", "c"]))}),
         pl.Schema({"e": pl.Enum(["x", "y"]), "c": pl.Categorical(), "n": pl.Int64()}),
     ],
 )


### PR DESCRIPTION
# Motivation

Arrow dictionary handling only applied to top-level fields, so nested enum schemas failed during Arrow PyCapsule conversion.

# Changes

- Centralize nested Arrow traversal in the core column converter.
- Preserve dictionary metadata recursively through child conversion callbacks.
- Cover list, struct, and map dictionaries plus Polars list enums.
- Verify 331 unit tests, Rust schema tests, formatting, linting, and Clippy.
