### PR TITLE
fix: Normalize Polars timestamps to UTC on write

### DIFF
--- a/ducklake-python/ducklake/polars/sink.py
+++ b/ducklake-python/ducklake/polars/sink.py
@@ -133,7 +133,7 @@ def _prepare_frame(lf: pl.LazyFrame, table: Table | TransactionTable) -> pl.Lazy
 
     # DuckLake stores timezone-aware timestamps in UTC. Polars considers datetimes with different
     # timezones to be distinct types, so normalize timezone-aware inputs before matching schemas.
-    lf = lf.pipe_with_schema(_convert_timestamp_timezones)
+    lf = lf.pipe_with_schema(_normalize_timestamp_timezones)
 
     # Ensure that the provided lazy frame aligns with the current schema of the table
     lf = lf.match_to_schema(target_schema)
@@ -149,7 +149,7 @@ def _prepare_frame(lf: pl.LazyFrame, table: Table | TransactionTable) -> pl.Lazy
     return lf
 
 
-def _convert_timestamp_timezones(lf: pl.LazyFrame, schema: pl.Schema) -> pl.LazyFrame:
+def _normalize_timestamp_timezones(lf: pl.LazyFrame, schema: pl.Schema) -> pl.LazyFrame:
     return lf.with_columns(
         pl.col(name).dt.convert_time_zone("UTC")
         for name, dtype in schema.items()

--- a/ducklake-python/ducklake/polars/sink.py
+++ b/ducklake-python/ducklake/polars/sink.py
@@ -129,8 +129,14 @@ def write_ducklake(df: pl.DataFrame, table: Table | TransactionTable) -> None:
 
 
 def _prepare_frame(lf: pl.LazyFrame, table: Table | TransactionTable) -> pl.LazyFrame:
+    target_schema = pl.Schema(table.schema)
+
+    # DuckLake stores timezone-aware timestamps in UTC. Polars considers datetimes with different
+    # timezones to be distinct types, so normalize timezone-aware inputs before matching schemas.
+    lf = lf.pipe_with_schema(_convert_timestamp_timezones)
+
     # Ensure that the provided lazy frame aligns with the current schema of the table
-    lf = lf.match_to_schema(pl.Schema(table.schema))
+    lf = lf.match_to_schema(target_schema)
 
     # Make sure that we apply the current defaults if there are any
     default_exprs = [
@@ -141,6 +147,14 @@ def _prepare_frame(lf: pl.LazyFrame, table: Table | TransactionTable) -> pl.Lazy
     if default_exprs:
         return lf.with_columns(default_exprs)
     return lf
+
+
+def _convert_timestamp_timezones(lf: pl.LazyFrame, schema: pl.Schema) -> pl.LazyFrame:
+    return lf.with_columns(
+        pl.col(name).dt.convert_time_zone("UTC")
+        for name, dtype in schema.items()
+        if isinstance(dtype, pl.Datetime) and dtype.time_zone is not None
+    )
 
 
 # ------------------------------------------- DEFAULTS ------------------------------------------ #

--- a/tests/unit/polars/test_write.py
+++ b/tests/unit/polars/test_write.py
@@ -83,6 +83,47 @@ def test_write_parquet(shared_ducklake: dl.Ducklake, random_table_name: str) -> 
     assert_frame_equal(df, roundtrip_df)
 
 
+@pytest.mark.parametrize(
+    "eager",
+    [
+        pytest.param(False, id="lazy"),
+        pytest.param(
+            True,
+            marks=pytest.mark.skip_config(
+                catalog="mysql", reason="Data inlining is not yet supported for MySQL."
+            ),
+            id="eager",
+        ),
+    ],
+)
+def test_write_converts_timestamp_timezone(
+    shared_ducklake: dl.Ducklake, random_table_name: str, eager: bool
+) -> None:
+    # Arrange
+    table = shared_ducklake.create_table(random_table_name, {"x": dl.TimestampTz()})
+    df = pl.DataFrame(
+        {
+            "x": pl.datetime_range(
+                dt.datetime(2024, 3, 31, 1),
+                dt.datetime(2024, 3, 31, 4),
+                interval="1h",
+                time_zone="Europe/Berlin",
+                eager=True,
+            )
+        }
+    )
+
+    # Act
+    if eager:
+        table.write_polars(df)
+    else:
+        table.sink_polars(df.lazy())
+
+    # Assert
+    expected = df.with_columns(pl.col("x").dt.convert_time_zone("UTC"))
+    assert_frame_equal(expected, table.read_polars())
+
+
 @pytest.mark.skip_config(catalog="mysql", reason="Data inlining is not yet supported for MySQL.")
 def test_write_parquet_inline(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
     # Arrange


### PR DESCRIPTION
# Motivation

DuckLake represents timezone-aware timestamps as UTC, while Polars treats each timezone as a distinct datetime type. As a result, writing a timezone-aware Polars column such as `datetime[μs, Europe/Berlin]` to a DuckLake `TimestampTz` column failed during `match_to_schema` because the target dtype is `datetime[μs, UTC]`.

Normalize timezone-aware Polars inputs to UTC before schema matching so their instants are preserved and both eager and lazy writes succeed.

# Changes

- Normalize timezone-aware Polars datetime columns to UTC through `pipe_with_schema`, without eagerly collecting the lazy-frame schema.
- Keep `match_to_schema` responsible for all other schema validation.
- Add a DST-boundary regression test parameterized across eager `write_polars` and lazy `sink_polars` writes.
- Validate the change with Ruff formatting and linting, `ty`, and the Polars write/inlining unit suites (42 passed, 1 skipped).
