### PR TITLE
fix: Normalize Polars timestamp precision on write

### DIFF
--- a/ducklake-python/ducklake/polars/sink.py
+++ b/ducklake-python/ducklake/polars/sink.py
@@ -156,8 +156,8 @@ def _normalize_timestamps(
         pl.col(name).cast(target_dtype)
         for name, source_dtype in source_schema.items()
         if (
-            (target_dtype := target_schema[name]) is not None
-            and isinstance(source_dtype, pl.Datetime)
+            isinstance(source_dtype, pl.Datetime)
+            and (target_dtype := target_schema.get(name)) is not None
             and isinstance(target_dtype, pl.Datetime)
             and (source_dtype.time_zone is None) == (target_dtype.time_zone is None)
         )

--- a/ducklake-python/ducklake/polars/sink.py
+++ b/ducklake-python/ducklake/polars/sink.py
@@ -152,18 +152,16 @@ def _prepare_frame(lf: pl.LazyFrame, table: Table | TransactionTable) -> pl.Lazy
 def _normalize_timestamps(
     lf: pl.LazyFrame, source_schema: pl.Schema, *, target_schema: pl.Schema
 ) -> pl.LazyFrame:
-    casts: list[pl.Expr] = []
-    for name, source_dtype in source_schema.items():
-        if name not in target_schema:
-            continue
-        target_dtype = target_schema[name]
+    return lf.with_columns(
+        pl.col(name).cast(target_dtype)
+        for name, source_dtype in source_schema.items()
         if (
-            isinstance(source_dtype, pl.Datetime)
+            (target_dtype := target_schema[name]) is not None
+            and isinstance(source_dtype, pl.Datetime)
             and isinstance(target_dtype, pl.Datetime)
             and (source_dtype.time_zone is None) == (target_dtype.time_zone is None)
-        ):
-            casts.append(pl.col(name).cast(target_dtype))
-    return lf.with_columns(casts)
+        )
+    )
 
 
 # ------------------------------------------- DEFAULTS ------------------------------------------ #

--- a/ducklake-python/ducklake/polars/sink.py
+++ b/ducklake-python/ducklake/polars/sink.py
@@ -2,6 +2,7 @@ from functools import partial
 from typing import Literal, overload
 
 import polars as pl
+import polars.datatypes as pld
 from polars._typing import EngineType
 from polars.io.partition import FileProviderArgs, SinkedPathsCallbackArgs
 from polars.lazyframe.opt_flags import DEFAULT_QUERY_OPT_FLAGS
@@ -153,15 +154,37 @@ def _normalize_timestamps(
     lf: pl.LazyFrame, source_schema: pl.Schema, *, target_schema: pl.Schema
 ) -> pl.LazyFrame:
     return lf.with_columns(
-        pl.col(name).cast(target_dtype)
-        for name, source_dtype in source_schema.items()
-        if (
-            isinstance(source_dtype, pl.Datetime)
-            and (target_dtype := target_schema.get(name)) is not None
-            and isinstance(target_dtype, pl.Datetime)
-            and (source_dtype.time_zone is None) == (target_dtype.time_zone is None)
+        pl.col(name).cast(
+            _normalize_timestamp_dtype(source_dtype, target_schema.get(name, source_dtype))
         )
+        for name, source_dtype in source_schema.items()
     )
+
+
+def _normalize_timestamp_dtype(
+    source_dtype: pl.DataType | pld.DataTypeClass,
+    target_dtype: pl.DataType | pld.DataTypeClass,
+) -> pl.DataType | pld.DataTypeClass:
+    match source_dtype, target_dtype:
+        case (
+            pl.Datetime(time_zone=source_time_zone),
+            pl.Datetime(time_zone=target_time_zone),
+        ) if (source_time_zone is None) == (target_time_zone is None):
+            return target_dtype
+        case pl.Struct(fields=source_fields), pl.Struct(fields=target_fields):
+            target_fields_by_name = {field.name: field.dtype for field in target_fields}
+            return pl.Struct(
+                {
+                    field.name: _normalize_timestamp_dtype(
+                        field.dtype, target_fields_by_name.get(field.name, field.dtype)
+                    )
+                    for field in source_fields
+                }
+            )
+        case pl.List(inner=source_inner), pl.List(inner=target_inner):
+            return pl.List(_normalize_timestamp_dtype(source_inner, target_inner))
+        case _:
+            return source_dtype
 
 
 # ------------------------------------------- DEFAULTS ------------------------------------------ #

--- a/ducklake-python/ducklake/polars/sink.py
+++ b/ducklake-python/ducklake/polars/sink.py
@@ -131,10 +131,9 @@ def write_ducklake(df: pl.DataFrame, table: Table | TransactionTable) -> None:
 def _prepare_frame(lf: pl.LazyFrame, table: Table | TransactionTable) -> pl.LazyFrame:
     target_schema = pl.Schema(table.schema)
 
-    # DuckLake stores timezone-aware timestamps as microseconds in UTC. Polars considers datetimes
-    # with different time units or timezones to be distinct types, so normalize timezone-aware
-    # inputs before matching schemas.
-    lf = lf.pipe_with_schema(_normalize_timestamps)
+    # Polars considers datetimes with different time units or timezones to be distinct types, so
+    # normalize compatible timestamp inputs before matching schemas.
+    lf = lf.pipe_with_schema(partial(_normalize_timestamps, target_schema=target_schema))
 
     # Ensure that the provided lazy frame aligns with the current schema of the table
     lf = lf.match_to_schema(target_schema)
@@ -150,12 +149,21 @@ def _prepare_frame(lf: pl.LazyFrame, table: Table | TransactionTable) -> pl.Lazy
     return lf
 
 
-def _normalize_timestamps(lf: pl.LazyFrame, schema: pl.Schema) -> pl.LazyFrame:
-    return lf.with_columns(
-        pl.col(name).cast(pl.Datetime("us", "UTC"))
-        for name, dtype in schema.items()
-        if isinstance(dtype, pl.Datetime) and dtype.time_zone is not None
-    )
+def _normalize_timestamps(
+    lf: pl.LazyFrame, source_schema: pl.Schema, *, target_schema: pl.Schema
+) -> pl.LazyFrame:
+    casts: list[pl.Expr] = []
+    for name, source_dtype in source_schema.items():
+        if name not in target_schema:
+            continue
+        target_dtype = target_schema[name]
+        if (
+            isinstance(source_dtype, pl.Datetime)
+            and isinstance(target_dtype, pl.Datetime)
+            and (source_dtype.time_zone is None) == (target_dtype.time_zone is None)
+        ):
+            casts.append(pl.col(name).cast(target_dtype))
+    return lf.with_columns(casts)
 
 
 # ------------------------------------------- DEFAULTS ------------------------------------------ #

--- a/ducklake-python/ducklake/polars/sink.py
+++ b/ducklake-python/ducklake/polars/sink.py
@@ -131,9 +131,10 @@ def write_ducklake(df: pl.DataFrame, table: Table | TransactionTable) -> None:
 def _prepare_frame(lf: pl.LazyFrame, table: Table | TransactionTable) -> pl.LazyFrame:
     target_schema = pl.Schema(table.schema)
 
-    # DuckLake stores timezone-aware timestamps in UTC. Polars considers datetimes with different
-    # timezones to be distinct types, so normalize timezone-aware inputs before matching schemas.
-    lf = lf.pipe_with_schema(_normalize_timestamp_timezones)
+    # DuckLake stores timezone-aware timestamps as microseconds in UTC. Polars considers datetimes
+    # with different time units or timezones to be distinct types, so normalize timezone-aware
+    # inputs before matching schemas.
+    lf = lf.pipe_with_schema(_normalize_timestamps)
 
     # Ensure that the provided lazy frame aligns with the current schema of the table
     lf = lf.match_to_schema(target_schema)
@@ -149,9 +150,9 @@ def _prepare_frame(lf: pl.LazyFrame, table: Table | TransactionTable) -> pl.Lazy
     return lf
 
 
-def _normalize_timestamp_timezones(lf: pl.LazyFrame, schema: pl.Schema) -> pl.LazyFrame:
+def _normalize_timestamps(lf: pl.LazyFrame, schema: pl.Schema) -> pl.LazyFrame:
     return lf.with_columns(
-        pl.col(name).dt.convert_time_zone("UTC")
+        pl.col(name).cast(pl.Datetime("us", "UTC"))
         for name, dtype in schema.items()
         if isinstance(dtype, pl.Datetime) and dtype.time_zone is not None
     )

--- a/tests/unit/polars/test_write.py
+++ b/tests/unit/polars/test_write.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from typing import Any
+from typing import Any, Literal
 
 import polars as pl
 import pytest
@@ -96,8 +96,19 @@ def test_write_parquet(shared_ducklake: dl.Ducklake, random_table_name: str) -> 
         ),
     ],
 )
-def test_write_converts_timestamp_timezone(
-    shared_ducklake: dl.Ducklake, random_table_name: str, eager: bool
+@pytest.mark.parametrize(
+    ("time_unit", "time_zone"),
+    [
+        pytest.param("us", "Europe/Berlin", id="timezone"),
+        pytest.param("ms", "UTC", id="precision"),
+    ],
+)
+def test_write_normalizes_timestamp(
+    shared_ducklake: dl.Ducklake,
+    random_table_name: str,
+    eager: bool,
+    time_unit: Literal["ms", "us"],
+    time_zone: str,
 ) -> None:
     # Arrange
     table = shared_ducklake.create_table(random_table_name, {"x": dl.TimestampTz()})
@@ -107,7 +118,8 @@ def test_write_converts_timestamp_timezone(
                 dt.datetime(2024, 3, 31, 1),
                 dt.datetime(2024, 3, 31, 4),
                 interval="1h",
-                time_zone="Europe/Berlin",
+                time_unit=time_unit,
+                time_zone=time_zone,
                 eager=True,
             )
         }
@@ -120,7 +132,7 @@ def test_write_converts_timestamp_timezone(
         table.sink_polars(df.lazy())
 
     # Assert
-    expected = df.with_columns(pl.col("x").dt.convert_time_zone("UTC"))
+    expected = df.with_columns(pl.col("x").cast(pl.Datetime("us", "UTC")))
     assert_frame_equal(expected, table.read_polars())
 
 

--- a/tests/unit/polars/test_write.py
+++ b/tests/unit/polars/test_write.py
@@ -1,7 +1,8 @@
 import datetime as dt
-from typing import Any, Literal
+from typing import Any
 
 import polars as pl
+import polars.exceptions as plexc
 import pytest
 import sqlalchemy as sa
 from polars.testing import assert_frame_equal
@@ -97,43 +98,74 @@ def test_write_parquet(shared_ducklake: dl.Ducklake, random_table_name: str) -> 
     ],
 )
 @pytest.mark.parametrize(
-    ("time_unit", "time_zone"),
+    ("ducklake_dtype", "source_dtype", "expected_dtype"),
     [
-        pytest.param("us", "Europe/Berlin", id="timezone"),
-        pytest.param("ms", "UTC", id="precision"),
+        pytest.param(
+            dl.TimestampTz(),
+            pl.Datetime("us", "Europe/Berlin"),
+            pl.Datetime("us", "UTC"),
+            id="timezone",
+        ),
+        pytest.param(
+            dl.TimestampTz(),
+            pl.Datetime("ms", "UTC"),
+            pl.Datetime("us", "UTC"),
+            id="timezone-aware-precision",
+        ),
+        pytest.param(
+            dl.Timestamp("microseconds"),
+            pl.Datetime("ms"),
+            pl.Datetime("us"),
+            id="timezone-naive-precision",
+        ),
+        pytest.param(
+            dl.TimestampTz(),
+            pl.Datetime("ms"),
+            None,
+            id="missing-timezone",
+        ),
     ],
 )
-def test_write_normalizes_timestamp(
+def test_write_matches_timestamp_schema(
     shared_ducklake: dl.Ducklake,
     random_table_name: str,
     eager: bool,
-    time_unit: Literal["ms", "us"],
-    time_zone: str,
+    ducklake_dtype: dl.DataType,
+    source_dtype: pl.Datetime,
+    expected_dtype: pl.Datetime | None,
 ) -> None:
     # Arrange
-    table = shared_ducklake.create_table(random_table_name, {"x": dl.TimestampTz()})
+    table = shared_ducklake.create_table(random_table_name, {"x": ducklake_dtype})
     df = pl.DataFrame(
         {
             "x": pl.datetime_range(
                 dt.datetime(2024, 3, 31, 1),
                 dt.datetime(2024, 3, 31, 4),
                 interval="1h",
-                time_unit=time_unit,
-                time_zone=time_zone,
+                time_unit=source_dtype.time_unit,
+                time_zone=source_dtype.time_zone,
                 eager=True,
             )
         }
     )
 
     # Act
-    if eager:
-        table.write_polars(df)
-    else:
-        table.sink_polars(df.lazy())
+    error: plexc.SchemaError | None = None
+    try:
+        if eager:
+            table.write_polars(df)
+        else:
+            table.sink_polars(df.lazy())
+    except plexc.SchemaError as exc:
+        error = exc
 
     # Assert
-    expected = df.with_columns(pl.col("x").cast(pl.Datetime("us", "UTC")))
-    assert_frame_equal(expected, table.read_polars())
+    if expected_dtype is None:
+        assert error is not None
+    else:
+        assert error is None
+        expected = df.with_columns(pl.col("x").cast(expected_dtype))
+        assert_frame_equal(expected, table.read_polars())
 
 
 @pytest.mark.skip_config(catalog="mysql", reason="Data inlining is not yet supported for MySQL.")

--- a/tests/unit/polars/test_write.py
+++ b/tests/unit/polars/test_write.py
@@ -1,5 +1,6 @@
 import datetime as dt
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import polars as pl
 import polars.exceptions as plexc
@@ -166,6 +167,75 @@ def test_write_matches_timestamp_schema(
         assert error is None
         expected = df.with_columns(pl.col("x").cast(expected_dtype))
         assert_frame_equal(expected, table.read_polars())
+
+
+@pytest.mark.parametrize(
+    "eager",
+    [
+        pytest.param(False, id="lazy"),
+        pytest.param(
+            True,
+            marks=pytest.mark.skip_config(
+                catalog="mysql", reason="Data inlining is not yet supported for MySQL."
+            ),
+            id="eager",
+        ),
+    ],
+)
+def test_write_matches_nested_timestamp_schema(
+    shared_ducklake: dl.Ducklake, random_table_name: str, eager: bool
+) -> None:
+    # Arrange
+    ducklake_dtype = dl.Struct(
+        {"events": dl.List(dl.Struct({"at": dl.TimestampTz(), "value": dl.Int64()}))}
+    )
+    table = shared_ducklake.create_table(
+        random_table_name,
+        {"x": ducklake_dtype},
+    )
+    source_dtype = pl.Struct(
+        {
+            "events": pl.List(
+                pl.Struct(
+                    {
+                        "at": pl.Datetime("ms", "Europe/Berlin"),
+                        "value": pl.Int64,
+                    }
+                )
+            )
+        }
+    )
+    df = pl.DataFrame(
+        {
+            "x": pl.Series(
+                [
+                    {
+                        "events": [
+                            {
+                                "at": dt.datetime(
+                                    2024, 3, 31, 1, tzinfo=ZoneInfo("Europe/Berlin")
+                                ),
+                                "value": 1,
+                            }
+                        ]
+                    },
+                    {"events": []},
+                ],
+                dtype=source_dtype,
+            )
+        }
+    )
+
+    # Act
+    if eager:
+        table.write_polars(df)
+    else:
+        table.sink_polars(df.lazy())
+
+    # Assert
+    expected_dtype = pl.Schema(table.schema)["x"]
+    expected = df.with_columns(pl.col("x").cast(expected_dtype))
+    assert_frame_equal(expected, table.read_polars())
 
 
 @pytest.mark.skip_config(catalog="mysql", reason="Data inlining is not yet supported for MySQL.")


### PR DESCRIPTION
# Motivation

Polars treats datetime time units as distinct types, so timestamp columns with a compatible timezone shape but a different precision fail during schema matching. Cast timestamp inputs to the corresponding DuckLake target dtype only when source and target are both timezone-aware or both timezone-naive, preserving target-specific precision without assuming a timezone for naive values.

Fixes #30.
