### PR TITLE
fix: Use correct overloads for `sink_polars`

### DIFF
--- a/ducklake-python/ducklake/table.py
+++ b/ducklake-python/ducklake/table.py
@@ -157,7 +157,7 @@ class Table:
         *,
         engine: EngineType = "auto",
         optimizations: pl.QueryOptFlags | None = None,
-        lazy: bool = False,
+        lazy: Literal[False] = False,
     ) -> None: ...
 
     @overload

--- a/ducklake-python/ducklake/transaction.py
+++ b/ducklake-python/ducklake/transaction.py
@@ -239,7 +239,7 @@ class TransactionTable:
         *,
         engine: EngineType = "auto",
         optimizations: pl.QueryOptFlags | None = None,
-        lazy: bool = False,
+        lazy: Literal[False] = False,
     ) -> None: ...
 
     @overload


### PR DESCRIPTION
# Motivation

This was wrong.
