### PR TITLE
fix: Normalize schema paths in transactions

### DIFF
--- a/crates/ducklake/src/transaction/schema.rs
+++ b/crates/ducklake/src/transaction/schema.rs
@@ -17,11 +17,12 @@ impl<'a> Transaction<'a> {
         }
 
         let path: io::DucklakePath = path.unwrap_or_else(|| name.to_string()).parse()?;
+        let path = path.ensure_directory();
         let schema_ref = self.catalog_mut().add_schema(name, path.clone())?;
         let change = Change::CreateSchema {
             schema_ref,
             name: name.to_string(),
-            path: path.ensure_directory(),
+            path,
         };
         self.changes.push(change);
         Ok(())

--- a/tests/unit/transaction/test_write.py
+++ b/tests/unit/transaction/test_write.py
@@ -1,17 +1,28 @@
 import polars as pl
+import pytest
 from polars.testing import assert_frame_equal
 
 import ducklake as dl
 
 
-def test_create_write_in_transaction(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
+@pytest.mark.parametrize("create_schema", [False, True])
+def test_create_write_in_transaction(
+    shared_ducklake: dl.Ducklake,
+    random_schema_name: str,
+    random_table_name: str,
+    create_schema: bool,
+) -> None:
+    # Arrange
     lf = pl.LazyFrame({"x": [1, 2, 3]})
+    table_name = (random_schema_name, random_table_name) if create_schema else random_table_name
 
     # Act
     with shared_ducklake.transaction() as tx:
-        table = tx.create_table(random_table_name, {"x": dl.Int64()})
+        if create_schema:
+            tx.create_schema(random_schema_name)
+        table = tx.create_table(table_name, {"x": dl.Int64()})
         table.sink_polars(lf)
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.get_table(table_name)
     assert_frame_equal(lf, table.scan_polars())


### PR DESCRIPTION
# Motivation

Schema paths without a trailing slash resolve same-transaction Polars writes outside the schema directory.

# Changes

Normalize schema paths before adding them to the transaction catalog and cover same-transaction writes.
