### PR TITLE
refactor: Standardize table lookup naming

### DIFF
--- a/ducklake-python/ducklake/ducklake.py
+++ b/ducklake-python/ducklake/ducklake.py
@@ -271,7 +271,7 @@ class Ducklake:
             self.time_zone,
         )
 
-    def get_table(self, name: str | tuple[str, str] | TableName) -> Table:
+    def table(self, name: str | tuple[str, str] | TableName) -> Table:
         """Read a table from the catalog.
 
         Args:
@@ -286,6 +286,10 @@ class Ducklake:
 
         Raises:
             NotFoundError: If the table does not exist.
+
+        Note:
+            The table is resolved against the latest snapshot. For a time-traveled DuckLake, it is
+            resolved against the pinned historical snapshot instead.
         """
         pytable = self._pyducklake.table(name)
         return Table._from_pytable(

--- a/tests/differential/test_write.py
+++ b/tests/differential/test_write.py
@@ -15,7 +15,7 @@ def test_match_reference_write_parquet(
 ) -> None:
     # Act
     ducklake.create_table("test", {"x": dl.Int64()})
-    table = ducklake.get_table("test")
+    table = ducklake.table("test")
     table.write_polars(pl.DataFrame({"x": range(100)}))
 
     reference_duckdb_connection.execute("CREATE TABLE test (x BIGINT)")
@@ -41,7 +41,7 @@ def test_match_reference_write_inline(
 ) -> None:
     # Act
     ducklake.create_table("test", {"x": dl.Int64()})
-    table = ducklake.get_table("test")
+    table = ducklake.table("test")
     table.write_polars(pl.DataFrame({"x": [1, 2, 3]}))
 
     reference_duckdb_connection.execute("CREATE TABLE test (x BIGINT)")

--- a/tests/unit/ducklake/test_readonly.py
+++ b/tests/unit/ducklake/test_readonly.py
@@ -9,7 +9,7 @@ import ducklake.exceptions as dlexc
 @pytest.fixture()
 def readonly_table(shared_ducklake: dl.Ducklake, random_table_name: str) -> dl.Table:
     shared_ducklake.create_table(random_table_name, {"x": dl.Int64()})
-    return shared_ducklake.readonly().get_table(random_table_name)
+    return shared_ducklake.readonly().table(random_table_name)
 
 
 def test_readonly_reads_follow_head(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
@@ -24,7 +24,7 @@ def test_readonly_reads_follow_head(shared_ducklake: dl.Ducklake, random_table_n
     table.sink_polars(lf)
 
     # Assert: unlike time travel, the read-only view sees the new commit (it follows head).
-    assert_frame_equal(pl.concat([lf, lf]), readonly.get_table(random_table_name).scan_polars())
+    assert_frame_equal(pl.concat([lf, lf]), readonly.table(random_table_name).scan_polars())
 
 
 def test_readonly_get_latest_snapshot_works(
@@ -114,7 +114,7 @@ def test_connect_readonly(catalog_url: str, storage_path: str, random_table_name
     # Act & Assert
     with dl.connect(catalog_url, readonly=True) as ducklake:
         # Reads work.
-        assert ducklake.get_table(random_table_name).read_polars().height == 3
+        assert ducklake.table(random_table_name).read_polars().height == 3
         # Writes are rejected.
         with pytest.raises(dlexc.ReadonlyDucklakeError):
             ducklake.create_table("other", {"x": dl.Int64()})

--- a/tests/unit/ducklake/test_tables.py
+++ b/tests/unit/ducklake/test_tables.py
@@ -39,10 +39,10 @@ def test_list_tables_filtered_by_schema(
     assert all(t.name.schema == "main" for t in tables_in_main)
 
 
-def test_get_table_not_found(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
+def test_table_not_found(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
     # Act & Assert
     with pytest.raises(dlexc.NotFoundError):
-        shared_ducklake.get_table(random_table_name)
+        shared_ducklake.table(random_table_name)
 
 
 def test_has_table(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
@@ -56,23 +56,23 @@ def test_has_table(shared_ducklake: dl.Ducklake, random_table_name: str) -> None
     assert not shared_ducklake.has_table(f"nonexistent_schema.{random_table_name}")
 
 
-def test_get_table_by_tuple(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
+def test_table_by_tuple(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
     # Arrange
     shared_ducklake.create_table(random_table_name, {"x": dl.Int64()})
 
     # Act
-    table = shared_ducklake.get_table(("main", random_table_name))
+    table = shared_ducklake.table(("main", random_table_name))
 
     # Assert
     assert table.name == ("main", random_table_name)
 
 
-def test_get_table_by_tablename(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
+def test_table_by_tablename(shared_ducklake: dl.Ducklake, random_table_name: str) -> None:
     # Arrange
     shared_ducklake.create_table(random_table_name, {"x": dl.Int64()})
 
     # Act
-    table = shared_ducklake.get_table(dl.TableName("main", random_table_name))
+    table = shared_ducklake.table(dl.TableName("main", random_table_name))
 
     # Assert
     assert table.name == ("main", random_table_name)

--- a/tests/unit/ducklake/test_time_travel.py
+++ b/tests/unit/ducklake/test_time_travel.py
@@ -17,7 +17,7 @@ def test_time_travel_by_snapshot_id(shared_ducklake: dl.Ducklake, random_table_n
     table.sink_polars(lf)
 
     # Act
-    time_traveled_table = shared_ducklake.at(snapshot_id).get_table(random_table_name)
+    time_traveled_table = shared_ducklake.at(snapshot_id).table(random_table_name)
 
     # Assert
     assert_frame_equal(pl.concat([lf, lf]), table.scan_polars())
@@ -41,7 +41,7 @@ def test_time_travel_by_fixed_timestamp(
     table.sink_polars(lf)
 
     # Act
-    time_traveled_table = shared_ducklake.at(snapshot_ts).get_table(random_table_name)
+    time_traveled_table = shared_ducklake.at(snapshot_ts).table(random_table_name)
 
     # Assert
     assert_frame_equal(pl.concat([lf, lf]), table.scan_polars())
@@ -62,7 +62,7 @@ def test_time_travel_by_fuzzy_timestamp(
     table.sink_polars(lf)
 
     # Act
-    time_traveled_table = shared_ducklake.at(snapshot_ts).get_table(random_table_name)
+    time_traveled_table = shared_ducklake.at(snapshot_ts).table(random_table_name)
 
     # Assert
     assert_frame_equal(pl.concat([lf, lf]), table.scan_polars())
@@ -73,7 +73,7 @@ def test_time_travel_no_transaction(shared_ducklake: dl.Ducklake, random_table_n
     # Arrange
     shared_ducklake.create_table(random_table_name, {"x": dl.Int64()})
     snapshot_id = shared_ducklake.get_latest_snapshot().id
-    time_traveled_table = shared_ducklake.at(snapshot_id).get_table(random_table_name)
+    time_traveled_table = shared_ducklake.at(snapshot_id).table(random_table_name)
 
     # Act
     with pytest.raises(dlexc.ReadonlyDucklakeError):
@@ -121,7 +121,7 @@ def test_time_travel_connect_at(
 
     # Act
     with dl.connect(catalog_url, at=snapshot_id) as ducklake:
-        traveled_table = ducklake.get_table(random_table_name)
+        traveled_table = ducklake.table(random_table_name)
 
         # Assert
         assert traveled_table.read_polars().height == 3

--- a/tests/unit/maintenance/test_dispatch_duckdb.py
+++ b/tests/unit/maintenance/test_dispatch_duckdb.py
@@ -107,7 +107,7 @@ def test_scan_after_expire_with_orphan_schema_versions(
 
     # Act: re-connect on same catalog to go around the cache
     with dl.connect(catalog_url) as reader:
-        result = reader.get_table(random_table_name).scan()
+        result = reader.table(random_table_name).scan()
 
     # Assert
     assert len(result.inline_data) == 2

--- a/tests/unit/table/test_write_data_files.py
+++ b/tests/unit/table/test_write_data_files.py
@@ -91,6 +91,6 @@ def test_write_data_files_in_transaction(ducklake: dl.Ducklake, random_table_nam
 
     # Assert
     assert_frame_equal(
-        ducklake.get_table(random_table_name).scan_polars().sort("x"),
+        ducklake.table(random_table_name).scan_polars().sort("x"),
         pl.LazyFrame({"x": [1, 2, 3]}, schema={"x": pl.Int64}),
     )

--- a/tests/unit/transaction/test_alter.py
+++ b/tests/unit/transaction/test_alter.py
@@ -19,7 +19,7 @@ def test_rename_table(shared_ducklake: dl.Ducklake, random_table_name: str) -> N
 
     # Assert
     assert transaction_table_name == ("main", new_table_name)
-    table = shared_ducklake.get_table(new_table_name)
+    table = shared_ducklake.table(new_table_name)
     assert table.name == ("main", new_table_name)
 
 
@@ -35,7 +35,7 @@ def test_add_column(shared_ducklake: dl.Ducklake, random_table_name: str) -> Non
         tx.table(random_table_name).add_column(dl.Column("y", dl.Varchar()))
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column("x", dl.Int64(), field_id=1),
         dl.Column("y", dl.Varchar(), field_id=2),
@@ -54,7 +54,7 @@ def test_rename_column(shared_ducklake: dl.Ducklake, random_table_name: str) -> 
         tx.table(random_table_name).rename_column("x", "y")
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [dl.Column("y", dl.Int64(), field_id=1)]
 
 
@@ -82,7 +82,7 @@ def test_remove_column(shared_ducklake: dl.Ducklake, random_table_name: str) -> 
         tx.table(random_table_name).remove_column("x")
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [dl.Column("y", dl.Varchar(), field_id=2)]
 
 
@@ -98,7 +98,7 @@ def test_update_column_dtype(shared_ducklake: dl.Ducklake, random_table_name: st
         tx.table(random_table_name).update_column_dtype("x", dl.Int64())
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [dl.Column("x", dl.Int64(), field_id=1)]
 
 
@@ -113,7 +113,7 @@ def test_update_column_dtype_struct(shared_ducklake: dl.Ducklake, random_table_n
         )
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column(
             "s",
@@ -137,7 +137,7 @@ def test_update_nested_column_dtype(shared_ducklake: dl.Ducklake, random_table_n
         tx.table(random_table_name).update_column_dtype("s", dl.Struct({"a": dl.Int64()}))
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column(
             "s",
@@ -167,7 +167,7 @@ def test_update_column_default(
         tx.table(random_table_name).update_column_default("x", default_value)
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column("x", dl.Int64(), field_id=1, default_value=default_value),
     ]
@@ -191,7 +191,7 @@ def test_update_column_nullability(
         tx.table(random_table_name).update_column_nullability("x", nullable)
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column("x", dl.Int64(), nullable=nullable, field_id=1),
     ]
@@ -209,7 +209,7 @@ def test_update_schema(shared_ducklake: dl.Ducklake, random_table_name: str) -> 
         tx.table(random_table_name).update_schema(dl.Schema({"x": dl.Int64(), "z": dl.Float64()}))
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column("x", dl.Int64(), field_id=1),
         dl.Column("z", dl.Float64(), field_id=3),
@@ -228,7 +228,7 @@ def test_add_column_tag(shared_ducklake: dl.Ducklake, random_table_name: str) ->
         tx.table(random_table_name).add_column_tag("x", "comment", "team-a")
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column("x", dl.Int64(), field_id=1, tags={"comment": "team-a"}),
     ]
@@ -246,7 +246,7 @@ def test_remove_column_tag(shared_ducklake: dl.Ducklake, random_table_name: str)
         tx.table(random_table_name).remove_column_tag("x", "comment")
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [dl.Column("x", dl.Int64(), field_id=1)]
 
 
@@ -259,7 +259,7 @@ def test_add_nested_column_tag(shared_ducklake: dl.Ducklake, random_table_name: 
         tx.table(random_table_name).add_column_tag(["s", "a"], "comment", "team-a")
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column(
             "s",
@@ -281,7 +281,7 @@ def test_add_table_tag(shared_ducklake: dl.Ducklake, random_table_name: str) -> 
         tx.table(random_table_name).add_tag("env", "prod")
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.tags == {"env": "prod"}
 
 
@@ -294,7 +294,7 @@ def test_remove_table_tag(shared_ducklake: dl.Ducklake, random_table_name: str) 
         tx.table(random_table_name).remove_tag("env")
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.tags == {}
 
 
@@ -310,7 +310,7 @@ def test_update_partitioning_set(shared_ducklake: dl.Ducklake, random_table_name
         tx.table(random_table_name).update_partitioning(dl.Partitioning("x"))
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.partitioning is not None
     assert [c.name for c in table.partitioning.columns] == ["x"]
 
@@ -324,7 +324,7 @@ def test_update_partitioning_reset(shared_ducklake: dl.Ducklake, random_table_na
         tx.table(random_table_name).update_partitioning(None)
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.partitioning is None
 
 
@@ -340,7 +340,7 @@ def test_rename_nested_column(shared_ducklake: dl.Ducklake, random_table_name: s
         tx.table(random_table_name).rename_column(["s", "a"], "b")
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column("s", dl.Struct([dl.Column("b", dl.Int64(), field_id=2)]), field_id=1),
     ]
@@ -358,7 +358,7 @@ def test_remove_nested_column(shared_ducklake: dl.Ducklake, random_table_name: s
         tx.table(random_table_name).remove_column(["s", "a"])
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column("s", dl.Struct([dl.Column("b", dl.Varchar(), field_id=3)]), field_id=1),
     ]
@@ -376,7 +376,7 @@ def test_remove_nested_column_tag(shared_ducklake: dl.Ducklake, random_table_nam
         tx.table(random_table_name).remove_column_tag(["s", "a"], "comment")
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [
         dl.Column("s", dl.Struct([dl.Column("a", dl.Int64(), field_id=2)]), field_id=1),
     ]

--- a/tests/unit/transaction/test_conflict_resolution.py
+++ b/tests/unit/transaction/test_conflict_resolution.py
@@ -38,7 +38,7 @@ def test_automatic_resolution_concurrent_write(
 
     # Assert
     expected = pl.concat([df, df])
-    assert_frame_equal(expected, shared_ducklake.get_table(random_table_name).read_polars())
+    assert_frame_equal(expected, shared_ducklake.table(random_table_name).read_polars())
 
 
 def test_automatic_resolution_with_true_conflict_and_inline_data_table_conflict(

--- a/tests/unit/transaction/test_table.py
+++ b/tests/unit/transaction/test_table.py
@@ -12,7 +12,7 @@ def test_create_table(shared_ducklake: dl.Ducklake, random_table_name: str) -> N
         tx.create_table(random_table_name, {"x": dl.Int64()})
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.name == ("main", random_table_name)
     assert table.schema.columns == [dl.Column("x", dl.Int64(), field_id=1)]
     assert table.partitioning is None
@@ -44,7 +44,7 @@ def test_delete_create_table(shared_ducklake: dl.Ducklake, random_table_name: st
         tx.create_table(random_table_name, {"y": dl.Int64()})
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.schema.columns == [dl.Column("y", dl.Int64(), field_id=1)]
 
 
@@ -69,7 +69,7 @@ def test_explicit_commit(shared_ducklake: dl.Ducklake, random_table_name: str) -
     tx.commit()
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.name == ("main", random_table_name)
 
 
@@ -84,7 +84,7 @@ def test_transaction_aborts_on_exception(
 
     # Assert: the table was never committed and is therefore not visible
     with pytest.raises(dlexc.NotFoundError):
-        shared_ducklake.get_table(random_table_name)
+        shared_ducklake.table(random_table_name)
 
 
 def test_create_table_with_partitioning_and_tags(
@@ -100,7 +100,7 @@ def test_create_table_with_partitioning_and_tags(
         )
 
     # Assert
-    table = shared_ducklake.get_table(random_table_name)
+    table = shared_ducklake.table(random_table_name)
     assert table.partitioning is not None
     assert [c.name for c in table.partitioning.columns] == ["x"]
     assert table.tags == {"env": "prod"}
@@ -116,7 +116,7 @@ def test_delete_table_in_transaction(shared_ducklake: dl.Ducklake, random_table_
 
     # Assert
     with pytest.raises(dlexc.NotFoundError):
-        shared_ducklake.get_table(random_table_name)
+        shared_ducklake.table(random_table_name)
 
 
 def test_list_tables_reflects_transaction_changes(

--- a/tests/unit/transaction/test_write.py
+++ b/tests/unit/transaction/test_write.py
@@ -24,5 +24,5 @@ def test_create_write_in_transaction(
         table.sink_polars(lf)
 
     # Assert
-    table = shared_ducklake.get_table(table_name)
+    table = shared_ducklake.table(table_name)
     assert_frame_equal(lf, table.scan_polars())


### PR DESCRIPTION
# Motivation

`Ducklake.get_table()` and `Transaction.table()` exposed the same table lookup operation under different names. Standardizing on `table()` makes the Python API consistent and follows common naming across Python analytics libraries.
